### PR TITLE
docs: prepare v0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Interactive mode provides a guided prompt flow for the most common human-facing 
 - `list`: browse existing worktrees and print the selected worktree path (equivalent to `ww cd`) for shell navigation, or remove them
 - `clean`: review cleanable worktrees before deletion
 
-Interactive mode is a thin wrapper over the standard CLI. It requires a TTY and is intended for people, not `--json` automation.
+Interactive mode is a thin wrapper over the standard CLI. It requires TTYs on stdin and stderr (stdout may be redirected) and is intended for people, not `--json` automation.
 
 ## Shell Integration
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ ww clean
 
 Removes all worktrees whose branches are already merged or whose remote tracking branches no longer exist. Use `--dry-run` to preview what would be cleaned.
 
+### Use interactive mode
+
+```sh
+ww i
+```
+
+Interactive mode provides a guided prompt flow for the most common human-facing operations:
+
+- `create`: pick a repo and branch, preview the target path, then create
+- `list`: browse existing worktrees and open or remove them
+- `clean`: review cleanable worktrees before deletion
+
+Interactive mode is a thin wrapper over the standard CLI. It requires a TTY and is intended for people, not `--json` automation.
+
 ## Shell Integration
 
 `ww` never changes your shell's current directory directly. Instead, it prints paths that shell wrappers or command substitution can consume.
@@ -190,6 +204,7 @@ post_create_hook = "npm install"
 | `ww list` | List all worktrees (across workspace in workspace mode) |
 | `ww remove <branch>` | Remove a worktree and delete its branch |
 | `ww clean` | Remove all merged or stale worktrees |
+| `ww i` | Start the interactive create/list/clean flow |
 | `ww cd [branch]` | Print a worktree path for shell navigation |
 | `ww version` | Print version information |
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ww i
 Interactive mode provides a guided prompt flow for the most common human-facing operations:
 
 - `create`: pick a repo and branch, preview the target path, then create
-- `list`: browse existing worktrees and open or remove them
+- `list`: browse existing worktrees and print the selected worktree path (equivalent to `ww cd`) for shell navigation, or remove them
 - `clean`: review cleanable worktrees before deletion
 
 Interactive mode is a thin wrapper over the standard CLI. It requires a TTY and is intended for people, not `--json` automation.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -95,8 +95,8 @@ When working in a meta-repo environment with many child repositories, parallel d
 - [x] Phase 1 (MVP): Single-repo worktree management — create, list, remove with post-create hooks and gitignored file handling.
 - [x] Phase 2: Workspace discovery (auto-detect parent/child git repos, `workspace = true`), cross-repo `ww list` with STATUS (`active`/`merged`/`stale`), `--cleanable` filter, `ww clean`, `--repo` flag for create/remove.
 - [ ] Post-Phase 2: `--no-upward-search` flag for sandboxed environments (FR-26). Small scope, independent of Phase 2 workspace discovery.
-- [ ] Phase 3: Polish — shell integration (`ww cd`, `cd $(ww create feat/x)`), SemVer release automation starting at `v0.3.0`, Homebrew tap distribution, documentation.
-- [ ] Phase 4: Human interactive mode — add a people-first interactive flow for common operations such as create, list, remove, clean, and worktree selection without requiring users to remember the full flag surface.
+- [x] Phase 3: Polish — shell integration (`ww cd`, `cd $(ww create feat/x)`), SemVer release automation starting at `v0.3.0`, Homebrew tap distribution, documentation.
+- [x] Phase 4: Human interactive mode — add a people-first interactive flow for common operations such as create, list, remove, clean, and worktree selection without requiring users to remember the full flag surface.
 - [ ] Phase 5 (nice-to-have): Hook trust hardening — first-run confirmation prompt, config change detection, sandbox execution, dangerous pattern warning.
 - [ ] Future: Sandboxed environment full compatibility (FR-25). Blocked on upstream Claude Code sandbox issue resolution.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,5 +9,6 @@ Detailed specifications for `ww` CLI behavior.
 | [git-operations.md](git-operations.md) | Low-level git operations used by `ww` |
 | [workspace-discovery.md](workspace-discovery.md) | Multi-repo workspace detection algorithm |
 | [shell-integration.md](shell-integration.md) | `ww cd`, `ww create -q`, and shell wrapper patterns |
+| [interactive-mode.md](interactive-mode.md) | Human-oriented `ww i` flows for create, list, open, remove, and clean |
 | [release-versioning.md](release-versioning.md) | SemVer tagging, build metadata, and release automation |
 | [testing.md](testing.md) | Testing strategy and test utilities |


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/done/interactive-mode-mvp.md`
- **Issues**: N/A

## Type of Change

- [x] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation only
- [x] Chore (CI, tooling, deps)

## Instructions

Execution: `N/A`
### Additional Context from Instructing Human

User requested that `ww` be released as `v0.4.0` now that Phase 4 interactive mode is implemented.

## Verification

- [ ] Tests pass (command: `N/A - doc-only PR`)
- [ ] Lint passes (command: `N/A - doc-only PR`)
- [x] Manual verification (describe below)

Manual verification:
- Confirmed `origin/main` already contains merged Phase 4 interactive mode work (`PR #118`, merged on 2026-04-10).
- Verified README now documents `ww i` and the command table includes interactive mode.
- Verified `docs/specs/README.md` now indexes `interactive-mode.md`.
- Verified `docs/project-plan.md` now marks Phase 3 and Phase 4 complete.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

Review focus:
- Whether marking both Phase 3 and Phase 4 complete in `docs/project-plan.md` matches the current shipped scope.
- Whether the README interactive-mode wording is sufficient for a `v0.4.0` release entry point.

## Links

N/A

## Breaking Changes

N/A

