### PR TITLE
Add plan for interactive action menu height

### DIFF
--- a/docs/exec-plan/todo/024-interactive-action-menu-height.md
+++ b/docs/exec-plan/todo/024-interactive-action-menu-height.md
@@ -1,0 +1,47 @@
+**Execution**: Use `/execute-task` to implement this plan.
+
+# 024 Interactive Action Menu Height
+
+## Objective
+
+Make the `ww i` select-based menus size their visible option area correctly so
+fixed action sets are fully visible and the worktree browser shows a stable
+five-row viewport.
+
+## Reproduction
+
+1. Run `ww i` in a workspace with multiple repos.
+2. Observe the top-level `Select action` prompt only showing part of the fixed
+   action set unless the user scrolls.
+3. Enter `list`, select a worktree, and observe the `Selected worktree` prompt
+   only showing part of its action set.
+4. Observe the worktree browser viewport using a height that does not match the
+   intended visible-row count.
+
+## Spec Changes
+
+- Update `docs/specs/interactive-mode.md` to require the top-level action picker
+  to render all fixed actions (`create`, `list`, `clean`, `quit`) without
+  scrolling.
+- Require the selected-worktree action picker to render all available actions at
+  once.
+- Document that the worktree browser shows up to five visible options before
+  scrolling.
+
+## Code Changes
+
+- Update `internal/interactive/huh_ui.go` to size select fields using helpers
+  that account for title and description rows.
+- Add regression tests covering the helper calculations and fixed action set.
+
+## Sub-tasks
+
+- [ ] Add the menu-visibility requirements to the interactive mode spec.
+- [ ] Adjust select height calculation for top-level actions, worktree list, and
+  selected-worktree actions.
+- [ ] Add regression tests for the helper functions and fixed action set.
+
+## Design Decisions
+
+- Keep the existing vertical `huh` UI. This change only fixes sizing so prompt
+  content is visible without unnecessary scrolling.

--- a/docs/exec-plan/todo/024-interactive-action-menu-height.md
+++ b/docs/exec-plan/todo/024-interactive-action-menu-height.md
@@ -37,10 +37,21 @@ five-row viewport.
 ## Sub-tasks
 
 - [ ] Add the menu-visibility requirements to the interactive mode spec.
-- [ ] Adjust select height calculation for top-level actions, worktree list, and
-  selected-worktree actions.
-- [ ] Add regression tests for the helper functions and fixed action set.
+- [ ] [depends on: spec] Adjust select height calculation for top-level actions,
+  worktree list, and selected-worktree actions.
+- [ ] [depends on: code] Add regression tests for the helper functions and fixed
+  action set.
 
+## Verification
+
+- Confirm the top-level `Select action` menu renders all four fixed actions
+  (`create`, `list`, `clean`, `quit`) without requiring scrolling.
+- Confirm the `Selected worktree` action menu renders all of its fixed actions
+  without requiring scrolling.
+- Confirm the worktree browser shows a stable five-row visible viewport before
+  scrolling is required.
+- Confirm regression tests cover the select-height helper calculations and the
+  fixed action-set sizing behavior.
 ## Design Decisions
 
 - Keep the existing vertical `huh` UI. This change only fixes sizing so prompt


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/todo/024-interactive-action-menu-height.md`
- **Issues**: N/A

## Type of Change

- [ ] Project Plan update
- [x] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `$plan-execution docs/exec-plan/todo/024-interactive-action-menu-height.md`
### Additional Context from Instructing Human

- Human reported that `ww i` top-level action choices were partially hidden and asked whether all actions could be shown.
- Human clarified that horizontal layout was unnecessary; the main requirement was to avoid hiding fixed choices.
- Human then reported the same height issue in the `list` flow's `Selected worktree` action menu and asked for a stable `5` visible worktree rows plus header behavior.
- Human explicitly redirected this turn to create the plan first before implementation.

## Verification

- [ ] Tests pass (command: `N/A (plan-only PR)`)
- [ ] Lint passes (command: `N/A (plan-only PR)`)
- [x] Manual verification (describe below)

Manual verification:
- Confirmed the new execution plan file exists on `plan/024-interactive-action-menu-height` and matches the reported scope.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- This PR plans a UI sizing fix only. Implementation PR should update spec-first, then adjust the `huh` select height calculations for top-level actions, selected-worktree actions, and the worktree browser viewport.

## Links

N/A

## Breaking Changes

N/A
