### PR TITLE
Add PTY smoke tests for interactive mode

### DIFF
--- a/docs/exec-plan/done/023-interactive-pty-smoke.md
+++ b/docs/exec-plan/done/023-interactive-pty-smoke.md
@@ -72,13 +72,13 @@ Apply the same reasoning here: add only enough PTY integration to catch real-ter
 
 ## Sub-tasks
 
-- [ ] [parallel] Update `docs/specs/testing.md` with PTY smoke-test expectations and limits
-- [ ] [parallel] Update `docs/specs/interactive-mode.md` with PTY-backed verification expectations for `quit` and `list -> open`
-- [ ] [depends on: specs] Choose and wire a Go PTY helper approach for integration tests
-- [ ] [depends on: PTY helper] Add a `ww i` smoke test that starts the real interactive session and exits via `quit`
-- [ ] [depends on: PTY helper] Add a `ww i` smoke test that drives `list -> open` and verifies path-only `stdout`
-- [ ] [depends on: PTY helper] Make the PTY harness robust against bounded rendering delays without relying on arbitrary long sleeps
-- [ ] [depends on: implementation] Run the relevant integration tests and confirm they pass reliably in the host-based test harness
+- [x] [parallel] Update `docs/specs/testing.md` with PTY smoke-test expectations and limits
+- [x] [parallel] Update `docs/specs/interactive-mode.md` with PTY-backed verification expectations for `quit` and `list -> open`
+- [x] [depends on: specs] Choose and wire a Go PTY helper approach for integration tests
+- [x] [depends on: PTY helper] Add a `ww i` smoke test that starts the real interactive session and exits via `quit`
+- [x] [depends on: PTY helper] Add a `ww i` smoke test that drives `list -> open` and verifies path-only `stdout`
+- [x] [depends on: PTY helper] Make the PTY harness robust against bounded rendering delays without relying on arbitrary long sleeps
+- [x] [depends on: implementation] Run the relevant integration tests and confirm they pass reliably in the host-based test harness
 
 ## Verification
 

--- a/docs/specs/interactive-mode.md
+++ b/docs/specs/interactive-mode.md
@@ -74,6 +74,11 @@ The current implementation step defines:
 
 Selecting `quit` exits successfully without writing to `stdout`.
 
+PTY-backed integration coverage must verify that `quit` works through the real
+prompt adapter under an actual TTY. The smoke test is expected to start
+`ww i`, wait for the top-level prompt to render, select `quit` with terminal
+key input, and observe a successful exit without a path-only action result.
+
 ## Shared Action Model
 
 The shared foundation defines stable action identifiers for the top-level menu:
@@ -168,6 +173,13 @@ clearly mark them and must not offer `remove`, matching the non-interactive
 - All prompts, menus, context, and any human-readable guidance remain on
   `stderr`.
 - After writing the path, the interactive session exits successfully.
+
+PTY-backed integration coverage must verify the real `list -> open` path. The
+smoke test is expected to create a secondary worktree, drive the top-level
+`list` action through the real prompt adapter, select a worktree, select
+`open`, and observe exactly the selected absolute path as the final stdout
+payload. Prompt rendering may include terminal control sequences, but the
+path-only result must remain distinguishable from human UI output.
 
 ### `remove`
 

--- a/docs/specs/testing.md
+++ b/docs/specs/testing.md
@@ -19,3 +19,16 @@ The test harness (`HostEnv`) provides:
 - **Command execution**: `Exec`, `Git`, `RunWW` run commands as host processes via `os/exec`, combining stdout and stderr.
 
 All tests may run in parallel. No Docker daemon or container runtime is required.
+
+## PTY-Backed Interactive Smoke Coverage
+
+`make test-all` includes a narrow PTY-backed smoke path for `ww i`. These tests run in the host-based integration harness and are skipped by `make test` because short mode excludes all integration tests.
+
+The PTY smoke harness starts the built `ww` binary with a pseudo-terminal attached to `stdin` and `stderr`, captures `stdout` separately, writes key sequences into the terminal, and waits for stable prompt checkpoints with bounded deadlines. This coverage is intentionally small:
+
+- starting `ww i` under a real TTY must pass the interactive TTY guard
+- selecting `quit` from the real prompt loop must exit successfully without writing a path or other action result
+- driving `list -> open` through the real prompt stack must exit successfully and emit exactly the selected absolute worktree path as the final stdout payload
+- prompt rendering and terminal control output are treated as human UI and are not asserted with golden snapshots
+
+The PTY tests prove prompt-library wiring, terminal input handling, and the interactive stdout/stderr contract at the integration boundary. Detailed branch logic remains covered by unit tests and non-PTY integration tests.

--- a/docs/specs/testing.md
+++ b/docs/specs/testing.md
@@ -24,7 +24,7 @@ All tests may run in parallel. No Docker daemon or container runtime is required
 
 `make test-all` includes a narrow PTY-backed smoke path for `ww i`. These tests run in the host-based integration harness and are skipped by `make test` because short mode excludes all integration tests.
 
-The PTY smoke harness starts the built `ww` binary with a pseudo-terminal attached to `stdin` and `stderr`, captures `stdout` separately, writes key sequences into the terminal, and waits for stable prompt checkpoints with bounded deadlines. This coverage is intentionally small:
+The PTY smoke harness starts the built `ww` binary with a pseudo-terminal attached to `stdin` and `stderr`, captures `stdout` separately, fixes `TERM=dumb` for deterministic accessible prompt rendering, writes key sequences into the terminal, and waits for stable prompt checkpoints with bounded deadlines. This coverage is intentionally small:
 
 - starting `ww i` under a real TTY must pass the interactive TTY guard
 - selecting `quit` from the real prompt loop must exit successfully without writing a path or other action result

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.5.0
+	github.com/creack/pty v1.1.24
 	github.com/spf13/pflag v1.0.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 h1:qko
 github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/integration_pty_test.go
+++ b/integration_pty_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/yoskeoka/ww/internal/testutil"
 )
 
 func TestInteractivePTYQuitSmoke(t *testing.T) {
@@ -89,11 +91,7 @@ func TestInteractivePTYListOpenSmoke(t *testing.T) {
 	}
 }
 
-func startInteractivePTY(t *testing.T, repo string) interface {
-	WriteKeys(string) error
-	WaitForOutput(string, time.Duration) error
-	Wait(time.Duration) (string, string, error)
-} {
+func startInteractivePTY(t *testing.T, repo string) *testutil.PTYSession {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
@@ -102,5 +100,8 @@ func startInteractivePTY(t *testing.T, repo string) interface {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		session.Close(time.Second)
+	})
 	return session
 }

--- a/integration_pty_test.go
+++ b/integration_pty_test.go
@@ -1,0 +1,106 @@
+//go:build !windows
+
+package integration_test
+
+import (
+	"context"
+	"path"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInteractivePTYQuitSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: integration test")
+	}
+	t.Parallel()
+
+	repo := setupRepo(t)
+	session := startInteractivePTY(t, repo)
+
+	if err := session.WaitForOutput("Select action", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WriteKeys("4\r"); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := session.Wait(5 * time.Second)
+	if err != nil {
+		t.Fatalf("ww i quit via PTY: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("ww i quit should not write stdout, got: %q", stdout)
+	}
+	if !strings.Contains(stderr, "Interactive mode") {
+		t.Fatalf("PTY output should include interactive overview, got:\n%s", stderr)
+	}
+}
+
+func TestInteractivePTYListOpenSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: integration test")
+	}
+	t.Parallel()
+
+	repo := setupRepo(t)
+	writeConfig(t, repo, `default_base = "main"`)
+	if _, err := runWW(t, repo, "create", "feat/pty-open"); err != nil {
+		t.Fatal(err)
+	}
+
+	session := startInteractivePTY(t, repo)
+	if err := session.WaitForOutput("Select action", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WriteKeys("2\r"); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WaitForOutput("Filter worktrees", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WriteKeys("\r"); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WaitForOutput("Select worktree", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WriteKeys("2\r"); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WaitForOutput("Selected worktree", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.WriteKeys("1\r"); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := session.Wait(5 * time.Second)
+	if err != nil {
+		t.Fatalf("ww i list -> open via PTY: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	wantPath := path.Join(path.Dir(repo), "myrepo@feat-pty-open")
+	if stdout != wantPath+"\n" {
+		t.Fatalf("ww i open stdout = %q, want %q\nstderr:\n%s", stdout, wantPath+"\n", stderr)
+	}
+	if strings.Contains(stdout, "Interactive mode") || strings.Contains(stdout, "Select action") {
+		t.Fatalf("stdout should contain only path output, got: %q", stdout)
+	}
+}
+
+func startInteractivePTY(t *testing.T, repo string) interface {
+	WriteKeys(string) error
+	WaitForOutput(string, time.Duration) error
+	Wait(time.Duration) (string, string, error)
+} {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	session, err := globalEnv.RunWWPTY(ctx, repo, "i")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session
+}

--- a/internal/interactive/huh_ui.go
+++ b/internal/interactive/huh_ui.go
@@ -65,12 +65,16 @@ func (ui *HuhListUI) SelectWorktree(items []WorktreeItem, filter string) (*Workt
 			Title("Filter worktrees").
 			Description("Match repo, branch, status, or full path. Leave empty for all.").
 			Value(&currentFilter),
+	)
+	if err != nil {
+		return nil, filter, err
+	}
+
+	err = runHuhForm(ui.Input, ui.Output,
 		huh.NewSelect[string]().
 			Title("Select worktree").
 			Description("Use arrows or j/k to move, enter to select, / to filter the visible list, q to quit.").
-			OptionsFunc(func() []huh.Option[string] {
-				return worktreeOptions(items, currentFilter, index)
-			}, &currentFilter).
+			Options(worktreeOptions(items, currentFilter, index)...).
 			Value(&selected).
 			Height(min(10, max(2, len(items)+1))),
 	)

--- a/internal/testutil/host.go
+++ b/internal/testutil/host.go
@@ -131,18 +131,7 @@ func (e *HostEnv) Exec(dir string, cmd string, args ...string) (string, error) {
 	if dir != "" {
 		c.Dir = dir
 	}
-	// Ensure our test git config path deterministically overrides any existing
-	// GIT_CONFIG_GLOBAL in the environment.
-	baseEnv := os.Environ()
-	env := make([]string, 0, len(baseEnv)+1)
-	for _, v := range baseEnv {
-		if strings.HasPrefix(v, "GIT_CONFIG_GLOBAL=") {
-			continue
-		}
-		env = append(env, v)
-	}
-	env = append(env, "GIT_CONFIG_GLOBAL="+e.gitConfigPath)
-	c.Env = env
+	c.Env = e.env()
 
 	out, err := c.CombinedOutput()
 	outStr := string(out)
@@ -163,16 +152,7 @@ func (e *HostEnv) ExecSplit(dir string, cmd string, args ...string) (string, str
 		c.Dir = dir
 	}
 
-	baseEnv := os.Environ()
-	env := make([]string, 0, len(baseEnv)+1)
-	for _, v := range baseEnv {
-		if strings.HasPrefix(v, "GIT_CONFIG_GLOBAL=") {
-			continue
-		}
-		env = append(env, v)
-	}
-	env = append(env, "GIT_CONFIG_GLOBAL="+e.gitConfigPath)
-	c.Env = env
+	c.Env = e.env()
 
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
@@ -187,6 +167,32 @@ func (e *HostEnv) ExecSplit(dir string, cmd string, args ...string) (string, str
 		return stdoutBuf.String(), stderrBuf.String(), err
 	}
 	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
+func (e *HostEnv) env(extra ...string) []string {
+	overrides := map[string]struct{}{"GIT_CONFIG_GLOBAL": {}}
+	for _, v := range extra {
+		overrides[envKey(v)] = struct{}{}
+	}
+
+	baseEnv := os.Environ()
+	env := make([]string, 0, len(baseEnv)+1+len(extra))
+	for _, v := range baseEnv {
+		if _, ok := overrides[envKey(v)]; ok {
+			continue
+		}
+		env = append(env, v)
+	}
+	env = append(env, "GIT_CONFIG_GLOBAL="+e.gitConfigPath)
+	env = append(env, extra...)
+	return env
+}
+
+func envKey(v string) string {
+	if key, _, ok := strings.Cut(v, "="); ok {
+		return key
+	}
+	return v
 }
 
 // buildWWBinaryHost compiles ww for the host OS/arch.

--- a/internal/testutil/pty_unix.go
+++ b/internal/testutil/pty_unix.go
@@ -43,7 +43,7 @@ func (e *HostEnv) RunWWPTY(ctx context.Context, dir string, args ...string) (*PT
 	if dir != "" {
 		c.Dir = dir
 	}
-	c.Env = testEnv(e.gitConfigPath)
+	c.Env = append(testEnv(e.gitConfigPath), "TERM=dumb")
 	stdout := &bytes.Buffer{}
 	c.Stdout = stdout
 

--- a/internal/testutil/pty_unix.go
+++ b/internal/testutil/pty_unix.go
@@ -1,0 +1,168 @@
+//go:build !windows
+
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// PTYSession is a running command with stdin and stderr attached to a
+// pseudo-terminal. Stdout remains separately captured so tests can assert the
+// shell-facing output contract.
+type PTYSession struct {
+	cmd    *exec.Cmd
+	pty    *os.File
+	cancel context.CancelFunc
+
+	stderrMu  sync.Mutex
+	stderrBuf bytes.Buffer
+	stdoutBuf *bytes.Buffer
+
+	waitOnce sync.Once
+	waitCh   chan error
+	readCh   chan error
+}
+
+// RunWWPTY starts ww with stdin and stderr attached to a pseudo-terminal.
+func (e *HostEnv) RunWWPTY(ctx context.Context, dir string, args ...string) (*PTYSession, error) {
+	if ctx == nil {
+		ctx = e.ctx
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	c := exec.CommandContext(ctx, e.wwBinaryPath, args...)
+	if dir != "" {
+		c.Dir = dir
+	}
+	c.Env = testEnv(e.gitConfigPath)
+	stdout := &bytes.Buffer{}
+	c.Stdout = stdout
+
+	ptmx, err := pty.StartWithSize(c, &pty.Winsize{Rows: 32, Cols: 120})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	session := &PTYSession{
+		cmd:       c,
+		pty:       ptmx,
+		cancel:    cancel,
+		waitCh:    make(chan error, 1),
+		readCh:    make(chan error, 1),
+		stdoutBuf: stdout,
+	}
+
+	go func() {
+		_, err := io.Copy(&lockedBuffer{mu: &session.stderrMu, buf: &session.stderrBuf}, ptmx)
+		session.readCh <- err
+	}()
+	go func() {
+		session.waitCh <- c.Wait()
+	}()
+
+	return session, nil
+}
+
+// WriteKeys sends terminal input to the running PTY.
+func (s *PTYSession) WriteKeys(keys string) error {
+	_, err := io.WriteString(s.pty, keys)
+	return err
+}
+
+// WaitForOutput waits until the PTY-rendered stderr contains text.
+func (s *PTYSession) WaitForOutput(text string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if strings.Contains(s.Stderr(), text) {
+			return nil
+		}
+		select {
+		case err := <-s.waitCh:
+			s.waitCh <- err
+			return fmt.Errorf("process exited before %q appeared: %w\nstderr:\n%s", text, err, s.Stderr())
+		default:
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %q\nstderr:\n%s", text, s.Stderr())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// Wait waits for the command to exit and returns captured stdout and PTY output.
+func (s *PTYSession) Wait(timeout time.Duration) (string, string, error) {
+	var waitErr error
+	done := make(chan struct{})
+	go func() {
+		s.waitOnce.Do(func() {
+			waitErr = <-s.waitCh
+			_ = s.pty.Close()
+			s.cancel()
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		s.cancel()
+		_ = s.pty.Close()
+		return s.Stdout(), s.Stderr(), fmt.Errorf("timed out waiting for process exit")
+	}
+
+	select {
+	case <-s.readCh:
+	case <-time.After(time.Second):
+	}
+
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			waitErr = fmt.Errorf("exit %d", exitErr.ExitCode())
+		}
+	}
+	return s.Stdout(), s.Stderr(), waitErr
+}
+
+func (s *PTYSession) Stdout() string {
+	return s.stdoutBuf.String()
+}
+
+func (s *PTYSession) Stderr() string {
+	s.stderrMu.Lock()
+	defer s.stderrMu.Unlock()
+	return s.stderrBuf.String()
+}
+
+type lockedBuffer struct {
+	mu  *sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func testEnv(gitConfigPath string) []string {
+	baseEnv := os.Environ()
+	env := make([]string, 0, len(baseEnv)+1)
+	for _, v := range baseEnv {
+		if strings.HasPrefix(v, "GIT_CONFIG_GLOBAL=") {
+			continue
+		}
+		env = append(env, v)
+	}
+	env = append(env, "GIT_CONFIG_GLOBAL="+gitConfigPath)
+	return env
+}

--- a/internal/testutil/pty_unix.go
+++ b/internal/testutil/pty_unix.go
@@ -43,7 +43,7 @@ func (e *HostEnv) RunWWPTY(ctx context.Context, dir string, args ...string) (*PT
 	if dir != "" {
 		c.Dir = dir
 	}
-	c.Env = append(testEnv(e.gitConfigPath), "TERM=dumb")
+	c.Env = e.env("TERM=dumb")
 	stdout := &bytes.Buffer{}
 	c.Stdout = stdout
 
@@ -89,7 +89,7 @@ func (s *PTYSession) WaitForOutput(text string, timeout time.Duration) error {
 		select {
 		case err := <-s.waitCh:
 			s.waitCh <- err
-			return fmt.Errorf("process exited before %q appeared: %w\nstderr:\n%s", text, err, s.Stderr())
+			return fmt.Errorf("process exited before %q appeared: %v\nstderr:\n%s", text, err, s.Stderr())
 		default:
 		}
 		if time.Now().After(deadline) {
@@ -133,6 +133,13 @@ func (s *PTYSession) Wait(timeout time.Duration) (string, string, error) {
 	return s.Stdout(), s.Stderr(), waitErr
 }
 
+// Close terminates the PTY session and waits briefly for process cleanup.
+func (s *PTYSession) Close(timeout time.Duration) {
+	s.cancel()
+	_ = s.pty.Close()
+	_, _, _ = s.Wait(timeout)
+}
+
 func (s *PTYSession) Stdout() string {
 	return s.stdoutBuf.String()
 }
@@ -152,17 +159,4 @@ func (b *lockedBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.Write(p)
-}
-
-func testEnv(gitConfigPath string) []string {
-	baseEnv := os.Environ()
-	env := make([]string, 0, len(baseEnv)+1)
-	for _, v := range baseEnv {
-		if strings.HasPrefix(v, "GIT_CONFIG_GLOBAL=") {
-			continue
-		}
-		env = append(env, v)
-	}
-	env = append(env, "GIT_CONFIG_GLOBAL="+gitConfigPath)
-	return env
 }


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/done/023-interactive-pty-smoke.md`
- **Issues**: N/A

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [x] Feature implementation
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `/execute-task ww/docs/exec-plan/todo/023-interactive-pty-smoke.md`

### Additional Context from Instructing Human

N/A

## Verification

- [x] Tests pass (command: `GOCACHE=/tmp/pj-go-build make test-all`)
- [x] Lint passes (command: `GOCACHE=/tmp/pj-go-build make lint`)
- [x] Manual verification (describe below)

Manual verification:

- `GOCACHE=/tmp/pj-go-build go test -run 'TestInteractivePTY|TestHuh|TestList' ./...`
- Verified PTY smoke covers `quit` and `list -> open` through the real `huh` prompt adapter.

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [x] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- The PTY helper attaches `stdin` and `stderr` to the pseudo-terminal while keeping `stdout` separately captured, so the `list -> open` smoke test can assert path-only stdout.
- The PTY test exposed that the worktree selector's dynamic `OptionsFunc` rendered zero options in the real terminal number-entry mode. The selector now gathers the filter in one form and renders a concrete option list in the next form.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

```text
$ GOCACHE=/tmp/pj-go-build make lint
go vet ./...

$ GOCACHE=/tmp/pj-go-build make test-all
go test ./...
ok  	github.com/yoskeoka/ww	27.168s
ok  	github.com/yoskeoka/ww/cmd/ww	0.486s
ok  	github.com/yoskeoka/ww/git	5.255s
ok  	github.com/yoskeoka/ww/internal/config	0.067s
ok  	github.com/yoskeoka/ww/internal/interactive	0.524s
?   	github.com/yoskeoka/ww/internal/testutil	[no test files]
ok  	github.com/yoskeoka/ww/validate	0.035s
ok  	github.com/yoskeoka/ww/workspace	4.580s
ok  	github.com/yoskeoka/ww/worktree	6.754s
```
