### PR TITLE
plan: update exec-plan README naming guidance

### DIFF
--- a/docs/exec-plan/todo/exec-plan-readme-numeric-filename-stale.md
+++ b/docs/exec-plan/todo/exec-plan-readme-numeric-filename-stale.md
@@ -1,0 +1,72 @@
+# Exec-plan README Numeric Filename Staleness
+**Execution**: Use `/execute-task` to implement this plan.
+
+## Objective
+
+Resolve `docs/issues/exec-plan-readme-numeric-filename-stale.md` by bringing the exec-plan directory README guidance back in line with the current workflow.
+
+The active README still documents numeric plan filenames such as `XXX-description.md`, but the current workspace workflow requires non-numeric, descriptive filenames that match the branch description. This plan keeps the fix limited to documentation and issue tracking.
+
+## Context Read
+
+- `docs/project-plan.md`: `ww` is intended to be agent-friendly and predictable. Stale workflow docs make automation and review feedback less predictable.
+- `docs/design-decisions/core-beliefs.md`: spec-code parity and AI-first context retrieval matter more than preserving outdated navigation conventions.
+- `docs/design-decisions/adr.md`: no existing ADR makes a product architecture decision about execution-plan naming. No ADR update is expected for this documentation cleanup.
+- `docs/exec-plan/done/`: completed plans include a mix of historical numeric and newer descriptive names. That history should be preserved; the current guidance should describe future/current workflow behavior without renaming old plans.
+
+## Code Changes
+
+No production or test code changes are expected.
+
+During execution, do not rename existing historical plan files in `docs/exec-plan/done/`. The issue explicitly scopes out that migration.
+
+## Spec Changes
+
+No `docs/specs/` change is expected because this is a workflow documentation cleanup, not a CLI behavior change.
+
+During execution, search the docs for other stale execution-plan naming guidance. Update only directly related workflow README text if it repeats the obsolete numeric convention.
+
+## Documentation and Issue Changes
+
+- Update `docs/exec-plan/todo/README.md` to state:
+  - active execution plans use non-numeric, descriptive kebab-case filenames
+  - the filename matches the branch description, for example `plan/remove-docker-from-integration-tests` maps to `docs/exec-plan/todo/remove-docker-from-integration-tests.md`
+  - completed plans move to `docs/exec-plan/done/` without being renamed into a numeric convention
+- Update `docs/exec-plan/done/README.md` if useful so the archive guidance does not imply a separate numeric naming rule.
+- Move `docs/issues/exec-plan-readme-numeric-filename-stale.md` to `docs/issues/done/exec-plan-readme-numeric-filename-stale.md` after the README guidance is corrected.
+
+## Scope Options
+
+- **Option A: Update only `docs/exec-plan/todo/README.md`.** This fixes the directly stale line with the smallest diff, but leaves the archive README too terse to prevent future confusion about whether completed plans need renaming.
+- **Option B: Update both `docs/exec-plan/todo/README.md` and `docs/exec-plan/done/README.md`.** This is still a small documentation-only change and addresses the issue's related README scope.
+
+Recommendation: choose Option B. It aligns both active and archive guidance while preserving historical completed filenames.
+
+## Sub-tasks
+
+- [ ] [parallel] Search workflow docs for stale `XXX-description.md`, numeric prefix, or completed-plan renaming guidance.
+- [ ] [parallel] Update `docs/exec-plan/todo/README.md` with the current non-numeric naming convention.
+- [ ] [parallel] Update `docs/exec-plan/done/README.md` with archive behavior and no-renaming guidance.
+- [ ] [depends on: README updates] Move the active issue file into `docs/issues/done/`.
+- [ ] [depends on: README updates, issue move] Run documentation-focused verification and inspect the final diff.
+
+## Parallelism
+
+The stale-guidance search and the two README edits are independent. The issue file move should wait until the README updates are complete.
+
+## Design Decisions
+
+No new architecture decision is expected. This plan applies the existing workflow rule that execution-plan filenames are descriptive and non-numeric, matching the branch description.
+
+## Verification
+
+- `rg -n "XXX-description|001-init|numeric prefix|numbered|no numeric|branch description" docs/exec-plan docs/issues .github`
+- `git diff --check`
+- `git status --short`
+
+## Success Criteria
+
+- `docs/exec-plan/todo/README.md` no longer instructs agents to use numeric plan filenames.
+- `docs/exec-plan/done/README.md`, if changed, clarifies archive behavior without requiring completed plans to be renamed.
+- `docs/issues/exec-plan-readme-numeric-filename-stale.md` is moved to `docs/issues/done/`.
+- No historical completed execution plans are renamed.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/todo/exec-plan-readme-numeric-filename-stale.md`
- **Issues**: `docs/issues/exec-plan-readme-numeric-filename-stale.md`

## Type of Change

- [ ] Project Plan update
- [x] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `ww/docs/issues/exec-plan-readme-numeric-filename-stale.md $plan-execution 実施`

### Additional Context from Instructing Human

N/A

## Verification

- [ ] Tests pass (command: `N/A - execution-plan-only documentation change`)
- [ ] Lint passes (command: `N/A - no code or lint-covered docs changed`)
- [x] Manual verification (describe below)

Manual verification:

- `git diff --check`
- Reviewed `docs/project-plan.md`, `docs/design-decisions/core-beliefs.md`, and `docs/design-decisions/adr.md`
- Reviewed the active issue and existing `docs/exec-plan/{todo,done}/README.md` files

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) - _if code changed_
- [x] Plan moved from `todo/` to `done/` - _if executing a plan_
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` - _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

This PR only adds the execution plan. The implementation should update the exec-plan README files and move the stale issue to `docs/issues/done/` after plan approval.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

N/A
