### PR TITLE
feat: add sandbox-constrained mode for ww

### DIFF
--- a/cmd/ww/helpers.go
+++ b/cmd/ww/helpers.go
@@ -19,12 +19,12 @@ func worktreeCreateOpts(glOpts *globalOpts, quiet bool) worktree.CreateOpts {
 	}
 }
 
-func managerForSelectedRepo(repoName string, requireRepo bool) (*worktree.Manager, error) {
+func managerForSelectedRepo(repoName string, requireRepo bool, sandbox bool) (*worktree.Manager, error) {
 	if repoName == "" {
-		return newManager(requireRepo)
+		return newManagerWithOptions(requireRepo, sandbox)
 	}
 
-	base, err := newManager(false)
+	base, err := newManagerWithOptions(false, sandbox)
 	if err != nil {
 		return nil, err
 	}
@@ -51,6 +51,7 @@ func managerForRepo(base *worktree.Manager, repoName string) (*worktree.Manager,
 				CopyFiles:      base.Config.CopyFiles,
 				SymlinkFiles:   base.Config.SymlinkFiles,
 				PostCreateHook: base.Config.PostCreateHook,
+				Sandbox:        base.Config.Sandbox,
 			},
 			RepoDir:   repo.Path,
 			Workspace: base.Workspace,

--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -118,6 +118,12 @@ func newManager(requireRepo bool) (*worktree.Manager, error) {
 	return newManagerWithOptions(requireRepo, false)
 }
 
+type managerContext struct {
+	ws      *workspace.Workspace
+	mainDir string
+	cfg     *config.Config
+}
+
 func newManagerWithOptions(requireRepo bool, sandboxFlag bool) (*worktree.Manager, error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -133,6 +139,40 @@ func newManagerWithOptions(requireRepo bool, sandboxFlag bool) (*worktree.Manage
 		sandboxMode = preCfg.Sandbox
 	}
 
+	ctx, err := loadManagerContext(dir, requireRepo, sandboxMode)
+	if err != nil {
+		return nil, err
+	}
+
+	// sandbox=true discovered only via fallback config paths must still
+	// affect workspace/config behavior, so rerun once in sandbox mode.
+	if !sandboxMode && ctx.cfg.Sandbox {
+		sandboxMode = true
+		ctx, err = loadManagerContext(dir, requireRepo, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+	sandboxMode = sandboxMode || ctx.cfg.Sandbox
+
+	runner := &git.Runner{Dir: dir}
+
+	return &worktree.Manager{
+		Git: runner,
+		Config: worktree.Config{
+			WorktreeDir:    ctx.cfg.WorktreeDir,
+			DefaultBase:    ctx.cfg.DefaultBase,
+			CopyFiles:      ctx.cfg.CopyFiles,
+			SymlinkFiles:   ctx.cfg.SymlinkFiles,
+			PostCreateHook: ctx.cfg.PostCreateHook,
+			Sandbox:        sandboxMode,
+		},
+		RepoDir:   ctx.mainDir,
+		Workspace: ctx.ws,
+	}, nil
+}
+
+func loadManagerContext(dir string, requireRepo bool, sandboxMode bool) (*managerContext, error) {
 	ws, err := workspace.DetectWithOptions(dir, workspace.DetectOptions{Sandbox: sandboxMode})
 	if err != nil {
 		return nil, err
@@ -158,21 +198,7 @@ func newManagerWithOptions(requireRepo bool, sandboxFlag bool) (*worktree.Manage
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
-	sandboxMode = sandboxMode || cfg.Sandbox
-
-	return &worktree.Manager{
-		Git: runner,
-		Config: worktree.Config{
-			WorktreeDir:    cfg.WorktreeDir,
-			DefaultBase:    cfg.DefaultBase,
-			CopyFiles:      cfg.CopyFiles,
-			SymlinkFiles:   cfg.SymlinkFiles,
-			PostCreateHook: cfg.PostCreateHook,
-			Sandbox:        sandboxMode,
-		},
-		RepoDir:   mainDir,
-		Workspace: ws,
-	}, nil
+	return &managerContext{ws: ws, mainDir: mainDir, cfg: cfg}, nil
 }
 
 func sandboxBoundary(ws *workspace.Workspace, mainDir string) string {
@@ -184,9 +210,6 @@ func sandboxBoundary(ws *workspace.Workspace, mainDir string) string {
 
 func sandboxFallbackDirs(sandbox bool, mainDir, workspaceRoot string) []string {
 	if sandbox {
-		if workspaceRoot != "" && workspaceRoot == mainDir {
-			return []string{mainDir}
-		}
 		return []string{mainDir}
 	}
 	return []string{mainDir, workspaceRoot}

--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -29,6 +29,7 @@ type globalOpts struct {
 	errOutput io.Writer
 	json      bool
 	dryRun    bool
+	sandbox   bool
 }
 
 type command struct {
@@ -53,6 +54,7 @@ func cliMain() int {
 	fset := pflag.NewFlagSet(mainCmdName, pflag.ContinueOnError)
 	fset.SetInterspersed(false)
 	showVersion := fset.Bool("version", false, "Print version")
+	sandbox := fset.Bool("sandbox", false, "Constrain discovery and worktree defaults to the current sandbox boundary")
 
 	fset.Usage = func() {
 		fmt.Fprintf(fset.Output(), "Usage: %s <command> [flags]\n\n", mainCmdName)
@@ -81,7 +83,7 @@ func cliMain() int {
 		return 1
 	}
 
-	glOpts := &globalOpts{output: os.Stdout, errOutput: os.Stderr}
+	glOpts := &globalOpts{output: os.Stdout, errOutput: os.Stderr, sandbox: *sandbox}
 	if err := runSubcmd(mainCmdName, commands, args, glOpts); err != nil {
 		if errors.Is(err, errHelp) {
 			return 0
@@ -113,12 +115,25 @@ func runSubcmd(parentCmd string, subCommands []command, args []string, glOpts *g
 }
 
 func newManager(requireRepo bool) (*worktree.Manager, error) {
+	return newManagerWithOptions(requireRepo, false)
+}
+
+func newManagerWithOptions(requireRepo bool, sandboxFlag bool) (*worktree.Manager, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 
-	ws, err := workspace.Detect(dir)
+	sandboxMode := sandboxFlag
+	if !sandboxMode {
+		preCfg, err := config.Load(dir)
+		if err != nil {
+			return nil, fmt.Errorf("loading config: %w", err)
+		}
+		sandboxMode = preCfg.Sandbox
+	}
+
+	ws, err := workspace.DetectWithOptions(dir, workspace.DetectOptions{Sandbox: sandboxMode})
 	if err != nil {
 		return nil, err
 	}
@@ -135,10 +150,15 @@ func newManager(requireRepo bool) (*worktree.Manager, error) {
 		}
 	}
 
-	cfg, err := config.Load(dir, mainDir, ws.Root)
+	cfg, err := config.LoadWithOptions(dir, config.LoadOptions{
+		Sandbox:      sandboxMode,
+		Boundary:     sandboxBoundary(ws, mainDir),
+		FallbackDirs: sandboxFallbackDirs(sandboxMode, mainDir, ws.Root),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
+	sandboxMode = sandboxMode || cfg.Sandbox
 
 	return &worktree.Manager{
 		Git: runner,
@@ -148,10 +168,28 @@ func newManager(requireRepo bool) (*worktree.Manager, error) {
 			CopyFiles:      cfg.CopyFiles,
 			SymlinkFiles:   cfg.SymlinkFiles,
 			PostCreateHook: cfg.PostCreateHook,
+			Sandbox:        sandboxMode,
 		},
 		RepoDir:   mainDir,
 		Workspace: ws,
 	}, nil
+}
+
+func sandboxBoundary(ws *workspace.Workspace, mainDir string) string {
+	if ws != nil && ws.Mode == workspace.ModeWorkspace && ws.Root != "" {
+		return ws.Root
+	}
+	return mainDir
+}
+
+func sandboxFallbackDirs(sandbox bool, mainDir, workspaceRoot string) []string {
+	if sandbox {
+		if workspaceRoot != "" && workspaceRoot == mainDir {
+			return []string{mainDir}
+		}
+		return []string{mainDir}
+	}
+	return []string{mainDir, workspaceRoot}
 }
 
 func outputJSON(w io.Writer, v any) error {

--- a/cmd/ww/sandbox_test.go
+++ b/cmd/ww/sandbox_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/yoskeoka/ww/workspace"
+)
+
+func TestSandboxRepoSelectionRejectedInsideChildRepo(t *testing.T) {
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	gitInitForSandboxTest(t, repoA)
+	gitInitForSandboxTest(t, repoB)
+
+	withCwd(t, repoA, func() {
+		_, err := managerForSelectedRepo("repo-b", true, true)
+		if err == nil {
+			t.Fatal("managerForSelectedRepo error = nil, want --repo rejection")
+		}
+		if got, want := err.Error(), "--repo can only be used inside a detected workspace"; got != want {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestSandboxRepoSelectionAllowedFromCurrentDirectoryWorkspaceRoot(t *testing.T) {
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	gitInitForSandboxTest(t, repoA)
+	gitInitForSandboxTest(t, repoB)
+
+	withCwd(t, root, func() {
+		mgr, err := managerForSelectedRepo("repo-b", true, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mgr.RepoDir != repoB {
+			t.Fatalf("RepoDir = %q, want %q", mgr.RepoDir, repoB)
+		}
+		if mgr.Workspace == nil || mgr.Workspace.Mode != workspace.ModeWorkspace {
+			t.Fatalf("Workspace = %+v, want workspace mode", mgr.Workspace)
+		}
+		if !mgr.Config.Sandbox {
+			t.Fatal("Config.Sandbox = false, want true")
+		}
+	})
+}
+
+func gitInitForSandboxTest(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init", "-b", "main")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s: %v\n%s", dir, err, string(out))
+	}
+}
+
+func withCwd(t *testing.T, dir string, fn func()) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(old); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	fn()
+}

--- a/cmd/ww/sandbox_test.go
+++ b/cmd/ww/sandbox_test.go
@@ -51,6 +51,47 @@ func TestSandboxRepoSelectionAllowedFromCurrentDirectoryWorkspaceRoot(t *testing
 	})
 }
 
+func TestSandboxConfigFoundViaFallbackRerunsDetectionInSandboxMode(t *testing.T) {
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	gitInitForSandboxTest(t, repoA)
+	gitInitForSandboxTest(t, repoB)
+
+	gitRun(t, repoA, "config", "user.email", "test@example.com")
+	gitRun(t, repoA, "config", "user.name", "Test User")
+	gitRun(t, repoA, "commit", "--allow-empty", "-m", "initial")
+
+	wtDir := filepath.Join(root, "repo-a-worktrees", "feat-sandbox")
+	if err := os.MkdirAll(filepath.Dir(wtDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repoA, "worktree", "add", "-b", "feat/sandbox", wtDir, "main")
+
+	if err := os.WriteFile(filepath.Join(repoA, ".ww.toml"), []byte("sandbox = true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	withCwd(t, wtDir, func() {
+		mgr, err := newManagerWithOptions(false, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !mgr.Config.Sandbox {
+			t.Fatal("Config.Sandbox = false, want true from fallback-loaded config")
+		}
+		if mgr.Workspace == nil {
+			t.Fatal("Workspace = nil, want single-repo workspace")
+		}
+		if mgr.Workspace.Mode != workspace.ModeSingleRepo {
+			t.Fatalf("Workspace.Mode = %q, want %q", mgr.Workspace.Mode, workspace.ModeSingleRepo)
+		}
+		if mgr.Workspace.Root != repoA {
+			t.Fatalf("Workspace.Root = %q, want %q", mgr.Workspace.Root, repoA)
+		}
+	})
+}
+
 func gitInitForSandboxTest(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -60,6 +101,15 @@ func gitInitForSandboxTest(t *testing.T, dir string) {
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init in %s: %v\n%s", dir, err, string(out))
+	}
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, string(out))
 	}
 }
 
@@ -74,7 +124,7 @@ func withCwd(t *testing.T, dir string, fn func()) {
 	}
 	defer func() {
 		if err := os.Chdir(old); err != nil {
-			t.Fatal(err)
+			t.Errorf("restore working directory to %q: %v", old, err)
 		}
 	}()
 	fn()

--- a/cmd/ww/sub_cd.go
+++ b/cmd/ww/sub_cd.go
@@ -28,7 +28,7 @@ func cdCmd() command {
 				return fmt.Errorf("usage: ww cd [branch]")
 			}
 
-			mgr, err := managerForSelectedRepo(*repo, true)
+			mgr, err := managerForSelectedRepo(*repo, true, glOpts.sandbox)
 			if err != nil {
 				return err
 			}

--- a/cmd/ww/sub_clean.go
+++ b/cmd/ww/sub_clean.go
@@ -37,7 +37,7 @@ func cleanCmd() command {
 			glOpts.json = glOpts.json || *jsonFlag
 			glOpts.dryRun = glOpts.dryRun || *dryRun
 
-			mgr, err := newManager(false)
+			mgr, err := newManagerWithOptions(false, glOpts.sandbox)
 			if err != nil {
 				return err
 			}

--- a/cmd/ww/sub_create.go
+++ b/cmd/ww/sub_create.go
@@ -30,7 +30,7 @@ func createCmd() command {
 			}
 			branch := remaining[0]
 
-			mgr, err := managerForSelectedRepo(*repo, true)
+			mgr, err := managerForSelectedRepo(*repo, true, glOpts.sandbox)
 			if err != nil {
 				return err
 			}

--- a/cmd/ww/sub_interactive.go
+++ b/cmd/ww/sub_interactive.go
@@ -50,7 +50,7 @@ func interactiveCmd() command {
 				return err
 			}
 
-			mgr, err := newManager(false)
+			mgr, err := newManagerWithOptions(false, glOpts.sandbox)
 			if err != nil {
 				return err
 			}
@@ -111,6 +111,7 @@ func interactiveCmd() command {
 						return executeCleanWorktrees(mgr, infos, &globalOpts{
 							output:    prompt,
 							errOutput: prompt,
+							sandbox:   glOpts.sandbox,
 						}, mode == interactive.CleanModeForce)
 					},
 				},

--- a/cmd/ww/sub_list.go
+++ b/cmd/ww/sub_list.go
@@ -25,7 +25,7 @@ func listCmd() command {
 			}
 			glOpts.json = glOpts.json || *jsonFlag
 
-			mgr, err := newManager(false)
+			mgr, err := newManagerWithOptions(false, glOpts.sandbox)
 			if err != nil {
 				return err
 			}

--- a/cmd/ww/sub_remove.go
+++ b/cmd/ww/sub_remove.go
@@ -33,7 +33,7 @@ func removeCmd() command {
 			}
 			branch := remaining[0]
 
-			mgr, err := managerForSelectedRepo(*repo, true)
+			mgr, err := managerForSelectedRepo(*repo, true, glOpts.sandbox)
 			if err != nil {
 				return err
 			}

--- a/docs/design-decisions/adr.md
+++ b/docs/design-decisions/adr.md
@@ -13,6 +13,27 @@
 
 ---
 
+## [2026-04-23] Sandbox-constrained mode overrides upward discovery and single-repo sibling layout
+
+### Context
+
+Normal workspace detection intentionally inspects a bounded parent/grandparent window so `ww` can infer practical meta-repo layouts without configuration. Normal single-repo mode also places worktrees beside the repository. Both choices are appropriate for unrestricted local shells, but they are poor defaults in filesystem-sandboxed AI agent environments where parent directories may be unreadable or writes beside the repo may be blocked.
+
+### Decision
+
+Add sandbox-constrained mode as `--sandbox` and `sandbox = true`. In sandbox mode, `ww` scans only the current directory's immediate children before falling back to the current repository. It does not inspect parent or grandparent directories to discover containing workspaces, and it does not scan parent siblings. Config lookup stops at the active sandbox boundary. Single-repo default worktrees move from sibling layout to `<repo_root>/.worktrees/<repo>@<branch>`, while current-directory workspace roots keep the workspace layout at `<workspace_root>/.worktrees/<repo>@<branch>`.
+
+Explicit user intent remains honored: absolute `worktree_dir` values and existing git worktree relationships are not rejected solely for pointing outside the sandbox-friendly default area. Relative `worktree_dir` values that escape their anchor with `..` remain rejected.
+
+### Consequences
+
+- **Positive**: `ww` can operate from the repository or bounded workspace directory without depending on parent directory access.
+- **Positive**: The feature name describes the complete behavior instead of only the upward-search mechanism.
+- **Negative**: From inside a child repository, sandbox mode cannot discover parent workspace siblings; users must start at the workspace root to use `--repo`.
+- **Negative**: Config-level `sandbox = true` can only help after a config file is reachable. In severely restricted environments, users should pass `--sandbox` explicitly.
+
+---
+
 ## [2026-03-18] Config type layering: worktree.Config vs flat fields
 
 ### Context

--- a/docs/exec-plan/done/no-upward-search.md
+++ b/docs/exec-plan/done/no-upward-search.md
@@ -116,16 +116,16 @@ Update specs before code:
 
 ## Sub-tasks
 
-- [ ] Update specs and project plan for sandbox-constrained mode.
-- [ ] Add ADR entry documenting why sandbox mode overrides existing workspace discovery and single-repo path defaults.
-- [ ] Implement global `--sandbox` flag and configuration field.
-- [ ] Implement sandbox-aware workspace detection without parent/grandparent scans while preserving current-directory child repo scans.
-- [ ] Implement sandbox-aware config search and path anchoring.
-- [ ] Preserve absolute out-of-bound config paths and existing git worktree relationships, while keeping relative `worktree_dir` escape rejection.
-- [ ] Add command-level `--repo` rejection coverage.
-- [ ] Add unit and integration tests.
-- [ ] Run `make test` and any narrower Go test commands needed while iterating.
-- [ ] Move this plan to `docs/exec-plan/done/` during execution.
+- [x] Update specs and project plan for sandbox-constrained mode.
+- [x] Add ADR entry documenting why sandbox mode overrides existing workspace discovery and single-repo path defaults.
+- [x] Implement global `--sandbox` flag and configuration field.
+- [x] Implement sandbox-aware workspace detection without parent/grandparent scans while preserving current-directory child repo scans.
+- [x] Implement sandbox-aware config search and path anchoring.
+- [x] Preserve absolute out-of-bound config paths and existing git worktree relationships, while keeping relative `worktree_dir` escape rejection.
+- [x] Add command-level `--repo` rejection coverage.
+- [x] Add unit and integration tests.
+- [x] Run `make test` and any narrower Go test commands needed while iterating.
+- [x] Move this plan to `docs/exec-plan/done/` during execution.
 
 ## Parallelism
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -57,7 +57,7 @@ When working in a meta-repo environment with many child repositories, parallel d
 
 #### Post-Phase 2
 
-- **FR-26**: `--no-upward-search` flag (or `.ww.toml` equivalent) — disable upward search for workspace detection and config discovery. In sandboxed environments (e.g., Claude Code), the process may not have permission to read parent directories or scan siblings. This flag constrains `ww` to the current repo only, skipping parent directory walks for `.ww.toml` config, workspace root detection, and sibling repo scanning. Implementation is small: skip the upward walk and sibling enumeration in the existing workspace discovery and config search logic.
+- **FR-26**: Sandbox-constrained mode (`--sandbox` flag or `sandbox = true` in `.ww.toml`) — make `ww` usable in filesystem-sandboxed environments that cannot reliably read or use parent directories. Sandbox mode skips parent/grandparent containing workspace detection, skips parent-based sibling scans, limits config lookup to the active sandbox boundary, and uses repo-local `.worktrees` placement for single-repo defaults. It still supports current-directory workspace roots by scanning immediate child repositories, so `--repo` remains available when the user starts at a bounded workspace root.
 
 #### Future
 
@@ -94,7 +94,7 @@ When working in a meta-repo environment with many child repositories, parallel d
 
 - [x] Phase 1 (MVP): Single-repo worktree management — create, list, remove with post-create hooks and gitignored file handling.
 - [x] Phase 2: Workspace discovery (auto-detect parent/child git repos, `workspace = true`), cross-repo `ww list` with STATUS (`active`/`merged`/`stale`), `--cleanable` filter, `ww clean`, `--repo` flag for create/remove.
-- [ ] Post-Phase 2: `--no-upward-search` flag for sandboxed environments (FR-26). Small scope, independent of Phase 2 workspace discovery.
+- [ ] Post-Phase 2: sandbox-constrained mode for sandboxed environments (FR-26). Independent of Phase 2 workspace discovery, but broader than a no-upward-search switch because it also affects config lookup and single-repo worktree placement.
 - [x] Phase 3: Polish — shell integration (`ww cd`, `cd $(ww create feat/x)`), SemVer release automation starting at `v0.3.0`, Homebrew tap distribution, documentation.
 - [x] Phase 4: Human interactive mode — add a people-first interactive flow for common operations such as create, list, remove, clean, and worktree selection without requiring users to remember the full flag surface.
 - [ ] Phase 5 (nice-to-have): Hook trust hardening — first-run confirmation prompt, config change detection, sandbox execution, dangerous pattern warning.

--- a/docs/specs/cli-commands.md
+++ b/docs/specs/cli-commands.md
@@ -8,6 +8,7 @@
 
 - `git` must be available in PATH. If not found, `ww` exits with a clear error: `git not found in PATH`.
 - Workspace-sensitive commands use the nearest containing workspace root selected by the workspace discovery algorithm.
+- When sandbox mode is enabled with `--sandbox` or `sandbox = true`, workspace-sensitive commands only use the current-directory workspace root or the current repository. Parent/grandparent containing workspace detection and parent-based sibling scans are skipped.
 - Detected workspace repositories are limited to real child repo roots. Immediate child symlinks, linked worktree checkouts, and helper directories with stray `.git` markers are excluded from workspace membership.
 - `ww` may be started from a non-git workspace root. `ww list` and `ww clean` work there without extra flags. `ww create` and `ww remove` require `--repo <name>` from that location; without it they exit with: `repo selection is not supported from a non-git workspace root`.
 - If the current directory is neither a git repository nor a detected workspace root, `ww` exits with: `not a git repository`.
@@ -20,6 +21,7 @@ When run from a secondary worktree, `ww` resolves back to the main working tree 
 |------|------|---------|-------------|
 | `--json` | bool | false | Output NDJSON (one JSON object per line) |
 | `--dry-run` | bool | false | Show planned actions without executing |
+| `--sandbox` | bool | false | Constrain workspace/config discovery and single-repo worktree defaults to the current sandbox boundary |
 | `--version` | bool | false | Print version and exit |
 
 ## Commands
@@ -33,6 +35,7 @@ Create a new worktree for the given branch.
    - If `--repo <name>` is omitted, use the current repository exactly as in Phase 1.
    - If `--repo <name>` is provided, require detected workspace mode, find the matching entry in the workspace child repo list by directory name, and operate on that repository.
    - If `--repo` is provided outside workspace mode, return an error: `--repo can only be used inside a detected workspace`.
+   - In sandbox mode, `--repo` is allowed only when the current directory itself is detected as a workspace root. From inside a child repository, sandbox mode resolves only that repository, so `--repo` returns: `--repo can only be used inside a detected workspace`.
    - If `--repo` names no detected repository, return an error: `repo "<name>" not found in workspace`.
 2. If a worktree directory already exists at the target path, return an error: `worktree already exists at <path>`.
 3. If the branch does not exist: create a new branch from `default_base` (config), `origin/HEAD`, or the heuristic `origin/main` / `origin/master` fallback and add a worktree for it.
@@ -45,6 +48,7 @@ If no base can be resolved for a new branch, the command must return an actionab
 
 **Worktree path:** mode-dependent default, or explicit `worktree_dir` override. Slashes in branch names are replaced with `-`.
 In workspace mode with `--repo`, the default path remains centralized at `<workspace_root>/.worktrees/<repo>@<branch>`.
+In sandbox single-repo mode, the default path is repo-local: `<repo_root>/.worktrees/<repo>@<branch>`.
 
 **Flags:**
 | Flag | Type | Default | Description |
@@ -94,6 +98,7 @@ Print the absolute path of a worktree for shell navigation.
    - If `--repo <name>` is omitted, use the current repository exactly as in Phase 1.
    - If `--repo <name>` is provided, require detected workspace mode, find the matching entry in the workspace child repo list by directory name, and operate on that repository.
    - If `--repo` is provided outside workspace mode, return an error: `--repo can only be used inside a detected workspace`.
+   - In sandbox mode, `--repo` is allowed only when the current directory itself is detected as a workspace root.
    - If `--repo` names no detected repository, return an error: `repo "<name>" not found in workspace`.
 2. If no branch argument is provided, resolve the most recently created secondary worktree for the target repository.
 3. If a branch argument is provided, match it against worktree branch names. `refs/heads/<branch>` and `<branch>` are treated as equivalent.

--- a/docs/specs/configuration.md
+++ b/docs/specs/configuration.md
@@ -22,6 +22,7 @@ symlink_files = [
 ]
 
 post_create_hook = "npm install"
+sandbox = false
 ```
 
 ## Fields
@@ -33,6 +34,7 @@ post_create_hook = "npm install"
 | `copy_files` | string[] | `[]` | Files/directories to deep-copy from main worktree to new worktrees. Missing sources are silently skipped; other errors emit a warning to stderr. |
 | `symlink_files` | string[] | `[]` | Files/directories to symlink from main worktree to new worktrees. Missing sources are silently skipped; other errors emit a warning to stderr. |
 | `post_create_hook` | string | `""` | Shell command to run in the new worktree directory after creation. Empty = no hook. |
+| `sandbox` | bool | `false` | Constrain workspace/config discovery and single-repo worktree defaults to the current sandbox boundary. The `--sandbox` CLI flag takes precedence and enables sandbox mode even when this field is absent or false. |
 
 ## Trust Model
 
@@ -46,6 +48,19 @@ post_create_hook = "npm install"
 4. Stop at the filesystem root.
 5. If not found via upward search, check caller-provided fallback directories (e.g., the main worktree's root directory or the detected workspace root).
 6. If no file is found, use defaults.
+
+### Sandbox Config Search
+
+When sandbox mode is enabled by `--sandbox` or by an already-loaded `sandbox = true` config value:
+
+1. Determine the sandbox boundary before loading the final config:
+   - if the current working directory has immediate child git repositories, the boundary is the current working directory
+   - otherwise, if the current working directory is inside git, the boundary is that repository's main working tree root
+   - otherwise, config loading uses defaults and command setup returns `not a git repository`
+2. Search from the current working directory upward, stopping at the sandbox boundary.
+3. If the current working directory is a secondary worktree that is not a descendant of the main working tree root, the main working tree root may be checked as an explicit fallback because git defines it as the repository's primary root.
+4. Other fallback directories outside the sandbox boundary are ignored.
+5. If no config is found within those locations, use defaults.
 
 ## Worktree Path Layout
 
@@ -61,6 +76,20 @@ myapp@fix-bug/      # worktree
 
 Path formula: `<repo-parent>/<repo-name>@<sanitized-branch>`
 
+### Sandbox single-repo layout (`worktree_dir = ""`)
+
+In sandbox single-repo mode, the default avoids parent-directory placement:
+
+```text
+myapp/                        # main repo
+├── .worktrees/
+│   ├── myapp@feat-auth/      # worktree
+│   └── myapp@fix-bug/        # worktree
+└── .ww.toml
+```
+
+Path formula: `<repo-root>/.worktrees/<repo-name>@<sanitized-branch>`
+
 ### Workspace layout (`worktree_dir = ".worktrees"` in workspace mode)
 
 Worktrees are created under the specified directory:
@@ -75,6 +104,8 @@ workspace/
 ```
 
 Path formula: `<worktree_dir>/<repo-name>@<sanitized-branch>`
+
+Relative `worktree_dir` values are resolved against the active anchor: the workspace root in workspace mode, the repository parent in normal single-repo mode, or the repository root in sandbox single-repo mode. Relative values that escape the active anchor with `..` are rejected. Absolute values are used as explicit user intent and are not rejected solely for pointing outside the sandbox-friendly default area.
 
 ## Branch Name Sanitization for Paths
 

--- a/docs/specs/shell-integration.md
+++ b/docs/specs/shell-integration.md
@@ -45,6 +45,7 @@ Phase 3 shell integration adds explicit path-printing interfaces for shell navig
 - If `post_create_hook` runs in quiet mode, its output is routed to `stderr` so `stdout` remains path-only.
 - With `--dry-run`, quiet mode prints the path that would be created.
 - With `--json`, JSON output takes precedence over quiet text mode.
+- With `--sandbox` in single-repo mode and no explicit `worktree_dir`, quiet mode prints the repo-local `.worktrees` path, e.g. `/path/to/repo/.worktrees/repo@feat-my-branch`.
 
 ## Supported Shell Patterns
 

--- a/docs/specs/workspace-discovery.md
+++ b/docs/specs/workspace-discovery.md
@@ -52,6 +52,19 @@ When the start directory is inside git:
    - it is the current main repo root itself, or one of those immediate child repositories contains the current main repo root
 5. If no candidate qualifies, treat the current repository as a standalone single-repo workspace.
 
+## Sandbox Mode
+
+Sandbox mode is enabled by the global `--sandbox` flag or by `sandbox = true` in `.ww.toml` when that config can be loaded. It constrains default discovery to the current sandbox boundary instead of trying to infer a containing workspace from parent directories.
+
+When sandbox mode is enabled:
+
+1. Scan only the current directory's immediate children for real git repositories.
+2. If child repositories are found, treat the current directory as a workspace root, even if the current directory is not itself a git repository.
+3. Otherwise, if the current directory is inside git, resolve the repository's main working tree root and operate in `single-repo` mode for that repository.
+4. Otherwise, return `not a git repository`.
+
+Sandbox mode does not inspect parent or grandparent directories while detecting a containing workspace. It also does not scan sibling repositories from a parent workspace candidate. From inside a child repository, sandbox mode therefore cannot discover parent workspace siblings, and commands using `--repo <name>` fail unless the current directory itself is a detected workspace root.
+
 ## Edge Cases
 
 - `.git` presence alone is not sufficient for workspace membership. Candidate children are validated with git top-level and git-dir/common-dir resolution.
@@ -73,12 +86,16 @@ When the start directory is inside git:
 |------|---------|------------------|
 | `workspace` | `.worktrees` | `<workspace_root>/.worktrees/<repo>@<branch>` |
 | `single-repo` | `""` | `<repo-parent>/<repo>@<branch>` |
+| `single-repo` with sandbox mode | `.worktrees` | `<repo_root>/.worktrees/<repo>@<branch>` |
 
 Behavior:
 - Explicit `worktree_dir` overrides the mode default in both modes.
 - Relative `worktree_dir` values are resolved against the workspace root in workspace mode.
 - Relative `worktree_dir` values are resolved against the repository parent in single-repo mode.
+- In sandbox single-repo mode, relative `worktree_dir` values are resolved against the repository root.
+- Relative `worktree_dir` values that escape their anchor with `..` are rejected, including in sandbox mode.
 - Absolute `worktree_dir` values are used as-is.
+- Absolute `worktree_dir` values are honored even if they point outside the sandbox-friendly default area. Any real sandbox denial is surfaced as the underlying filesystem or git error.
 
 ## CLI Prerequisite
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -16,15 +17,33 @@ type Config struct {
 	CopyFiles      []string `toml:"copy_files"`
 	SymlinkFiles   []string `toml:"symlink_files"`
 	PostCreateHook string   `toml:"post_create_hook"`
+	Sandbox        bool     `toml:"sandbox"`
+}
+
+// LoadOptions controls config search behavior.
+type LoadOptions struct {
+	Sandbox      bool
+	Boundary     string
+	FallbackDirs []string
 }
 
 // Load searches upward from startDir for .ww.toml and parses it.
 // If the upward search fails, it checks each directory in fallbackDirs
 // for .ww.toml. Returns default config if no file is found.
 func Load(startDir string, fallbackDirs ...string) (*Config, error) {
-	path := findConfig(startDir)
+	return LoadWithOptions(startDir, LoadOptions{FallbackDirs: fallbackDirs})
+}
+
+// LoadWithOptions searches for .ww.toml using the provided search options and parses it.
+func LoadWithOptions(startDir string, opts LoadOptions) (*Config, error) {
+	var path string
+	if opts.Sandbox {
+		path = findConfigBounded(startDir, opts.Boundary)
+	} else {
+		path = findConfig(startDir)
+	}
 	if path == "" {
-		path = findConfigInDirs(fallbackDirs)
+		path = findConfigInDirs(opts.FallbackDirs)
 	}
 	if path == "" {
 		return &Config{}, nil
@@ -47,6 +66,34 @@ func findConfig(dir string) string {
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// findConfigBounded searches upward from dir for .ww.toml, stopping after
+// checking boundary. If boundary is empty, it behaves like an unbounded search.
+func findConfigBounded(dir, boundary string) string {
+	if boundary == "" {
+		return findConfig(dir)
+	}
+	dir, _ = filepath.Abs(dir)
+	boundary, _ = filepath.Abs(boundary)
+	for {
+		candidate := filepath.Join(dir, FileName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		if filepath.Clean(dir) == filepath.Clean(boundary) {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		rel, err := filepath.Rel(boundary, parent)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return ""
 		}
 		dir = parent

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,6 +31,7 @@ default_base = "origin/main"
 copy_files = [".env"]
 symlink_files = ["node_modules"]
 post_create_hook = "npm install"
+sandbox = true
 `
 	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -51,6 +52,9 @@ post_create_hook = "npm install"
 	}
 	if cfg.PostCreateHook != "npm install" {
 		t.Errorf("PostCreateHook = %q, want 'npm install'", cfg.PostCreateHook)
+	}
+	if !cfg.Sandbox {
+		t.Errorf("Sandbox = false, want true")
 	}
 }
 
@@ -146,5 +150,68 @@ func TestLoadFallbackSkipsEmptyString(t *testing.T) {
 	}
 	if cfg.WorktreeDir != "from-fallback" {
 		t.Errorf("WorktreeDir = %q, want from-fallback", cfg.WorktreeDir)
+	}
+}
+
+func TestLoadSandboxStopsAtBoundary(t *testing.T) {
+	parentDir := t.TempDir()
+	boundary := filepath.Join(parentDir, "repo")
+	startDir := filepath.Join(boundary, "sub")
+	if err := os.MkdirAll(startDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentDir, FileName), []byte(`worktree_dir = "from-parent"`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(boundary, FileName), []byte(`worktree_dir = "from-boundary"`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadWithOptions(startDir, LoadOptions{Sandbox: true, Boundary: boundary})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorktreeDir != "from-boundary" {
+		t.Errorf("WorktreeDir = %q, want from-boundary", cfg.WorktreeDir)
+	}
+}
+
+func TestLoadSandboxIgnoresConfigAboveBoundary(t *testing.T) {
+	parentDir := t.TempDir()
+	boundary := filepath.Join(parentDir, "repo")
+	startDir := filepath.Join(boundary, "sub")
+	if err := os.MkdirAll(startDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentDir, FileName), []byte(`worktree_dir = "from-parent"`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadWithOptions(startDir, LoadOptions{Sandbox: true, Boundary: boundary})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorktreeDir != "" {
+		t.Errorf("WorktreeDir = %q, want default", cfg.WorktreeDir)
+	}
+}
+
+func TestLoadSandboxAllowsMainWorktreeFallback(t *testing.T) {
+	currentCheckout := t.TempDir()
+	mainWorktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(mainWorktree, FileName), []byte(`worktree_dir = "from-main"`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadWithOptions(currentCheckout, LoadOptions{
+		Sandbox:      true,
+		Boundary:     mainWorktree,
+		FallbackDirs: []string{mainWorktree},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorktreeDir != "from-main" {
+		t.Errorf("WorktreeDir = %q, want from-main", cfg.WorktreeDir)
 	}
 }

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -33,12 +33,22 @@ type Workspace struct {
 	Mode  Mode
 }
 
+// DetectOptions controls workspace discovery behavior.
+type DetectOptions struct {
+	Sandbox bool
+}
+
 // ErrNotGitRepository is returned when detection finds no git repository and
 // no valid workspace root.
 var ErrNotGitRepository = errors.New("not a git repository")
 
 // Detect inspects startDir and returns the detected workspace layout.
 func Detect(startDir string) (*Workspace, error) {
+	return DetectWithOptions(startDir, DetectOptions{})
+}
+
+// DetectWithOptions inspects startDir and returns the detected workspace layout.
+func DetectWithOptions(startDir string, opts DetectOptions) (*Workspace, error) {
 	absStart, err := filepath.Abs(startDir)
 	if err != nil {
 		return nil, err
@@ -47,6 +57,16 @@ func Detect(startDir string) (*Workspace, error) {
 	childRepos, err := scanImmediateRepos(absStart)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.Sandbox && len(childRepos) > 0 {
+		repos := childRepos
+		if ok, err := isStandaloneRepoRoot(absStart); err != nil {
+			return nil, err
+		} else if ok {
+			repos = append(repos, Repo{Name: filepath.Base(absStart), Path: absStart})
+		}
+		return &Workspace{Root: absStart, Repos: normalizeRepos(repos), Mode: ModeWorkspace}, nil
 	}
 
 	runner := &git.Runner{Dir: absStart}
@@ -65,6 +85,17 @@ func Detect(startDir string) (*Workspace, error) {
 	mainRoot, err = filepath.Abs(mainRoot)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.Sandbox {
+		return &Workspace{
+			Root: mainRoot,
+			Repos: []Repo{{
+				Name: filepath.Base(mainRoot),
+				Path: mainRoot,
+			}},
+			Mode: ModeSingleRepo,
+		}, nil
 	}
 
 	if wsRoot, ok, err := detectContainingWorkspace(absStart, mainRoot); err != nil {

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -380,6 +380,50 @@ func TestDetectWorktreeSiblingNotCountedAsWorkspaceMember(t *testing.T) {
 	}
 }
 
+func TestDetectSandboxFromChildRepoDoesNotDiscoverParentWorkspace(t *testing.T) {
+	root := evalTempDir(t)
+	childA := filepath.Join(root, "child-a")
+	childB := filepath.Join(root, "child-b")
+	gitInit(t, childA)
+	gitInit(t, childB)
+
+	ws, err := DetectWithOptions(childA, DetectOptions{Sandbox: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.Mode != ModeSingleRepo {
+		t.Fatalf("Mode = %q, want %q", ws.Mode, ModeSingleRepo)
+	}
+	if ws.Root != childA {
+		t.Fatalf("Root = %q, want %q", ws.Root, childA)
+	}
+	if got := repoNames(ws.Repos); !reflect.DeepEqual(got, []string{"child-a"}) {
+		t.Fatalf("Repos = %v, want [child-a]", got)
+	}
+}
+
+func TestDetectSandboxCurrentDirectoryWorkspaceRoot(t *testing.T) {
+	root := evalTempDir(t)
+	childA := filepath.Join(root, "child-a")
+	childB := filepath.Join(root, "child-b")
+	gitInit(t, childA)
+	gitInit(t, childB)
+
+	ws, err := DetectWithOptions(root, DetectOptions{Sandbox: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.Mode != ModeWorkspace {
+		t.Fatalf("Mode = %q, want %q", ws.Mode, ModeWorkspace)
+	}
+	if ws.Root != root {
+		t.Fatalf("Root = %q, want %q", ws.Root, root)
+	}
+	if got := repoNames(ws.Repos); !reflect.DeepEqual(got, []string{"child-a", "child-b"}) {
+		t.Fatalf("Repos = %v, want [child-a child-b]", got)
+	}
+}
+
 func repoNames(repos []Repo) []string {
 	names := make([]string, len(repos))
 	for i, repo := range repos {

--- a/worktree/worktree.go
+++ b/worktree/worktree.go
@@ -32,6 +32,7 @@ type Config struct {
 	CopyFiles      []string
 	SymlinkFiles   []string
 	PostCreateHook string
+	Sandbox        bool
 }
 
 // Manager coordinates worktree operations.
@@ -104,6 +105,8 @@ func (m *Manager) worktreeLocation(branch string) (string, string, error) {
 			var anchor string
 			if m.isWorkspaceMode() {
 				anchor = m.Workspace.Root
+			} else if m.Config.Sandbox {
+				anchor = m.RepoDir
 			} else {
 				anchor = repoParent
 			}
@@ -125,6 +128,11 @@ func (m *Manager) worktreeLocation(branch string) (string, string, error) {
 	if m.isWorkspaceMode() {
 		base := filepath.Join(m.Workspace.Root, ".worktrees")
 		return filepath.Join(base, dirName), m.Workspace.Root, nil
+	}
+
+	if m.Config.Sandbox {
+		base := filepath.Join(m.RepoDir, ".worktrees")
+		return filepath.Join(base, dirName), m.RepoDir, nil
 	}
 
 	return filepath.Join(repoParent, dirName), m.RepoDir, nil

--- a/worktree/worktree.go
+++ b/worktree/worktree.go
@@ -114,7 +114,7 @@ func (m *Manager) worktreeLocation(branch string) (string, string, error) {
 			base = filepath.Join(cleanAnchor, base)
 			// Reject relative paths that escape the anchor root via ".." traversal.
 			rel, relErr := filepath.Rel(cleanAnchor, base)
-			if relErr != nil || strings.HasPrefix(rel, "..") {
+			if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 				return "", "", fmt.Errorf("worktree_dir %q resolves outside the allowed area %q", m.Config.WorktreeDir, anchor)
 			}
 			if m.isWorkspaceMode() {

--- a/worktree/worktree_test.go
+++ b/worktree/worktree_test.go
@@ -60,6 +60,21 @@ func TestWorktreePathWorkspaceDefault(t *testing.T) {
 	}
 }
 
+func TestWorktreePathSandboxSingleRepoDefault(t *testing.T) {
+	m := &Manager{
+		Config:  Config{Sandbox: true},
+		RepoDir: "/tmp/project",
+	}
+	got, err := m.WorktreePath("feat/my-feature")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/tmp/project", ".worktrees", "project@feat-my-feature")
+	if got != want {
+		t.Fatalf("WorktreePath = %q, want %q", got, want)
+	}
+}
+
 func TestWorktreePathRelativeOverrideWorkspace(t *testing.T) {
 	m := &Manager{
 		Config:  Config{WorktreeDir: "custom"},
@@ -117,6 +132,32 @@ func TestWorktreePathRelativeOverrideSingleRepo(t *testing.T) {
 	want := filepath.Join("/tmp", "worktrees", "project@feat-my-feature")
 	if got != want {
 		t.Fatalf("WorktreePath = %q, want %q", got, want)
+	}
+}
+
+func TestWorktreePathRelativeOverrideSandboxSingleRepo(t *testing.T) {
+	m := &Manager{
+		Config:  Config{WorktreeDir: "worktrees", Sandbox: true},
+		RepoDir: "/tmp/project",
+	}
+	got, err := m.WorktreePath("feat/my-feature")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/tmp/project", "worktrees", "project@feat-my-feature")
+	if got != want {
+		t.Fatalf("WorktreePath = %q, want %q", got, want)
+	}
+}
+
+func TestWorktreePathRelativeEscapeSandboxSingleRepo(t *testing.T) {
+	m := &Manager{
+		Config:  Config{WorktreeDir: "../outside", Sandbox: true},
+		RepoDir: "/tmp/project",
+	}
+	_, err := m.WorktreePath("feat/my-feature")
+	if err == nil {
+		t.Fatal("expected error for relative worktree_dir that escapes repo root, got nil")
 	}
 }
 
@@ -366,6 +407,66 @@ func TestCreateExistingBranchDoesNotRequireBase(t *testing.T) {
 	}
 	if len(log) == 0 || !strings.Contains(log[0], "existing branch: feat/existing") {
 		t.Fatalf("Create() dry-run log = %#v, want existing branch message", log)
+	}
+}
+
+func TestCreateSandboxSingleRepoUsesRepoLocalWorktrees(t *testing.T) {
+	repo, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &git.Runner{Dir: repo}
+	mustGit(t, runner, "init", "-b", "main")
+	mustGit(t, runner, "config", "user.email", "test@example.com")
+	mustGit(t, runner, "config", "user.name", "Test User")
+	writeStatusFile(t, repo, "README.md", "# repo\n")
+	mustGit(t, runner, "add", ".")
+	mustGit(t, runner, "commit", "-m", "initial")
+
+	mgr := &Manager{
+		Git:     runner,
+		Config:  Config{DefaultBase: "main", Sandbox: true},
+		RepoDir: repo,
+	}
+
+	info, _, err := mgr.Create("feat/sandbox", CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(repo, ".worktrees", filepath.Base(repo)+"@feat-sandbox")
+	if info.Path != want {
+		t.Fatalf("Create path = %q, want %q", info.Path, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("created worktree not found at %s: %v", want, err)
+	}
+}
+
+func TestCreateSandboxRelativeEscapeRejected(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &git.Runner{Dir: repo}
+	mustGit(t, runner, "init", "-b", "main")
+	mustGit(t, runner, "config", "user.email", "test@example.com")
+	mustGit(t, runner, "config", "user.name", "Test User")
+	writeStatusFile(t, repo, "README.md", "# repo\n")
+	mustGit(t, runner, "add", ".")
+	mustGit(t, runner, "commit", "-m", "initial")
+
+	mgr := &Manager{
+		Git:     runner,
+		Config:  Config{DefaultBase: "main", WorktreeDir: "../outside", Sandbox: true},
+		RepoDir: repo,
+	}
+
+	_, _, err := mgr.Create("feat/escape", CreateOpts{})
+	if err == nil {
+		t.Fatal("Create error = nil, want relative worktree_dir escape error")
+	}
+	if !strings.Contains(err.Error(), "resolves outside the allowed area") {
+		t.Fatalf("Create error = %q, want escape diagnostic", err)
 	}
 }
 


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/done/no-upward-search.md`
- **Issues**: N/A

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [x] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `/execute-task ww/docs/exec-plan/todo/no-upward-search.md`
### Additional Context from Instructing Human

`これを実行`

## Verification

- [x] Tests pass (command: `make test && go test ./workspace ./internal/config ./worktree ./cmd/ww`)
- [x] Lint passes (command: `make lint`)
- [x] Manual verification (describe below)

Manual verification: sandbox mode path layout and repo-selection constraints are covered by new/updated tests in `cmd/ww`, `workspace`, `internal/config`, and `worktree`.

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [x] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

Focus review on sandbox boundary semantics:

1. Global flag and config interaction (`--sandbox` and `sandbox = true`)
2. Workspace detection behavior in sandbox mode (current dir children only; no parent/grandparent containing workspace scans)
3. Single-repo sandbox default path (`<repo>/.worktrees/...`) and relative/absolute `worktree_dir` handling
4. `--repo` behavior from workspace root vs child repo when sandbox is enabled

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

- `make lint` (pass)
- `make test` (pass)
- `go test ./workspace ./internal/config ./worktree ./cmd/ww` (pass)
