### PR TITLE
Plan workspace direntry prefilter follow-up

### DIFF
--- a/docs/exec-plan/todo/workspace-direntry-prefilter-followup.md
+++ b/docs/exec-plan/todo/workspace-direntry-prefilter-followup.md
@@ -1,0 +1,61 @@
+# workspace-direntry-prefilter-followup
+> **Execution**: Use `/execute-task` to implement this plan.
+
+**Objective**: Reduce duplicate `Lstat` work in the child-entry prefilter inside `workspace.scanImmediateRepos()`, and make the boundary between `DirEntry` prefiltering and symlink/repo validation clearer. Keep public behavior unchanged while improving readability and maintainability.
+
+## Context
+
+- `docs/issues/workspace-direntry-prefilter-followup.md` identifies this as a low-priority refactor: current behavior is correct, but non-directory paths can trigger redundant `Lstat` calls.
+- Existing spec expectations (`docs/specs/workspace-discovery.md`) must remain intact: immediate child symlinks are not followed by default, and only real git repositories are treated as workspace members.
+- Consistent with ADR direction (2026-03-31, 2026-04-23), workspace detection should stay bounded and conservative.
+
+## Options and Trade-offs
+
+1. **No code change (keep as-is)**
+   - Pros: Zero implementation risk and effort.
+   - Cons: The issue intent (simplify redundant checks) remains unresolved, and readability cost persists for future edits.
+2. **Lightweight refactor passing `os.DirEntry` into `isImmediateChildRepo` (recommended)**
+   - Pros: Clarifies the boundary between cheap prefiltering and repo validation, and limits `Lstat` to places that actually need it. Low risk because behavior stays unchanged.
+   - Cons: Function signature changes require unit test updates.
+3. **Larger refactor to propagate richer file metadata end-to-end**
+   - Pros: Could reduce repeated stat work more systematically.
+   - Cons: Over-scoped for this low-priority follow-up and increases regression risk across workspace detection logic.
+
+**Recommendation**: Option 2. Refine helper boundaries around `DirEntry` while preserving external behavior, so this issue is resolved without broad logic changes.  
+**Decision (2026-04-23)**: Human confirmed Option 2; this plan is locked to the lightweight refactor path.
+
+## Spec Changes
+
+- Default direction: **no spec behavior change** (public behavior remains as-is).
+- Only if clarification is necessary, add a minimal note in `docs/specs/workspace-discovery.md` Edge Cases that child-entry prefiltering still preserves the no-follow-symlink policy.
+
+## Code Changes
+
+- `workspace/workspace.go`
+  - Restructure early filtering in `scanImmediateRepos` around `os.DirEntry`.
+  - Adjust `isImmediateChildRepo` input boundaries so `Lstat` is only used when extra metadata is required.
+  - Preserve current symlink-ignore behavior, standalone repo validation, and `os.ErrNotExist` handling.
+
+## Test Changes
+
+- `workspace/workspace_test.go`
+  - Update or add tests proving non-directory and symlink child handling stays unchanged.
+  - Add explicit regression coverage that the workspace member set does not change.
+
+## Sub-tasks
+
+- [ ] Refactor helper boundaries in `workspace/workspace.go` to use `DirEntry` where appropriate and remove duplicate `Lstat` calls
+- [ ] [parallel] Update `workspace/workspace_test.go` coverage to confirm no behavior change
+- [ ] [depends on: implementation and test updates] Add minimal clarification to `docs/specs/workspace-discovery.md` only if needed
+- [ ] [depends on: implementation and test updates] Run `go test ./workspace` for targeted verification
+
+## Verification
+
+- `go test ./workspace`
+- Optional if needed: `go test ./...`
+- Manual check: create fixtures with regular files, symlink children, and real child repos; confirm detected repo set matches current behavior
+
+## Expected Outcome
+
+- `scanImmediateRepos` flow is easier to read and duplicate `Lstat` work is reduced.
+- Public workspace discovery behavior (real repo membership and no-follow child symlink policy) remains unchanged.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/todo/workspace-direntry-prefilter-followup.md`
- **Issues**: `docs/issues/workspace-direntry-prefilter-followup.md`

## Type of Change

- [ ] Project Plan update
- [x] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `$plan-execution ww/docs/issues/workspace-direntry-prefilter-followup.md`

### Additional Context from Instructing Human

- AI compared three options for the follow-up plan. Human confirmed Option 2: lightweight refactor passing `os.DirEntry` into `isImmediateChildRepo`.
- Human requested the plan be written consistently in English.

## Verification

- [ ] Tests pass (command: `N/A - planning-only documentation change`)
- [x] Lint passes (command: `.claude/vendor/workflow/tools/workflow-lint.sh --mode=pre-push`)
- [x] Manual verification (describe below)

Manual verification:
- Confirmed the plan file is English-only with `rg -n "[ぁ-んァ-ン一-龯]" docs/exec-plan/todo/workspace-direntry-prefilter-followup.md`.
- Reviewed the plan against the issue context and existing workspace discovery spec.
- Ran workflow linter in pre-push mode; all checks passed.

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) - _if code changed_
- [x] Plan moved from `todo/` to `done/` - _if executing a plan_
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` - _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

Review focus: confirm the selected Option 2 scope is appropriately narrow for the low-priority follow-up issue, and that implementation should preserve workspace discovery behavior.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

N/A
