### PR TITLE
docs: mark Post-Phase 2 complete in project plan

### DIFF
--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -57,7 +57,9 @@ When working in a meta-repo environment with many child repositories, parallel d
 
 #### Post-Phase 2
 
-- **FR-26**: Sandbox-constrained mode (`--sandbox` flag or `sandbox = true` in `.ww.toml`) — make `ww` usable in filesystem-sandboxed environments that cannot reliably read or use parent directories. Sandbox mode skips parent/grandparent containing workspace detection, skips parent-based sibling scans, limits config lookup to the active sandbox boundary, and uses repo-local `.worktrees` placement for single-repo defaults. It still supports current-directory workspace roots by scanning immediate child repositories, so `--repo` remains available when the user starts at a bounded workspace root.
+Post-Phase 2 (originally tracked as no-upward-search) is complete. The planned follow-up landed via the sandbox implementation, so this item is no longer an open phase. Any remaining sandbox-related refinements should be tracked as separate follow-up tasks rather than under Post-Phase 2.
+
+- **FR-26**: Sandbox-constrained mode (`--sandbox` flag or `sandbox = true` in `.ww.toml`) — completed via the sandbox implementation. `ww` can operate in filesystem-sandboxed environments that cannot reliably read or use parent directories by skipping parent/grandparent containing workspace detection, skipping parent-based sibling scans, limiting config lookup to the active sandbox boundary, and using repo-local `.worktrees` placement for single-repo defaults. It still supports current-directory workspace roots by scanning immediate child repositories, so `--repo` remains available when the user starts at a bounded workspace root.
 
 #### Future
 
@@ -94,7 +96,7 @@ When working in a meta-repo environment with many child repositories, parallel d
 
 - [x] Phase 1 (MVP): Single-repo worktree management — create, list, remove with post-create hooks and gitignored file handling.
 - [x] Phase 2: Workspace discovery (auto-detect parent/child git repos, `workspace = true`), cross-repo `ww list` with STATUS (`active`/`merged`/`stale`), `--cleanable` filter, `ww clean`, `--repo` flag for create/remove.
-- [ ] Post-Phase 2: sandbox-constrained mode for sandboxed environments (FR-26). Independent of Phase 2 workspace discovery, but broader than a no-upward-search switch because it also affects config lookup and single-repo worktree placement.
+- [x] Post-Phase 2: sandbox-constrained mode for sandboxed environments (FR-26). Originally tracked as no-upward-search, and completed via the sandbox implementation. Any further sandbox refinements should be handled as separate follow-up tasks rather than this phase.
 - [x] Phase 3: Polish — shell integration (`ww cd`, `cd $(ww create feat/x)`), SemVer release automation starting at `v0.3.0`, Homebrew tap distribution, documentation.
 - [x] Phase 4: Human interactive mode — add a people-first interactive flow for common operations such as create, list, remove, clean, and worktree selection without requiring users to remember the full flag surface.
 - [ ] Phase 5 (nice-to-have): Hook trust hardening — first-run confirmation prompt, config change detection, sandbox execution, dangerous pattern warning.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -57,7 +57,7 @@ When working in a meta-repo environment with many child repositories, parallel d
 
 #### Post-Phase 2
 
-Post-Phase 2 (originally tracked as no-upward-search) is complete. The planned follow-up landed via the sandbox implementation, so this item is no longer an open phase. Any remaining sandbox-related refinements should be tracked as separate follow-up tasks rather than under Post-Phase 2.
+Post-Phase 2 (originally tracked as `--no-upward-search`) is complete. The planned follow-up landed via the sandbox implementation, so this item is no longer an open phase. Any remaining sandbox-related refinements should be tracked as separate follow-up tasks rather than under Post-Phase 2.
 
 - **FR-26**: Sandbox-constrained mode (`--sandbox` flag or `sandbox = true` in `.ww.toml`) — completed via the sandbox implementation. `ww` can operate in filesystem-sandboxed environments that cannot reliably read or use parent directories by skipping parent/grandparent containing workspace detection, skipping parent-based sibling scans, limiting config lookup to the active sandbox boundary, and using repo-local `.worktrees` placement for single-repo defaults. It still supports current-directory workspace roots by scanning immediate child repositories, so `--repo` remains available when the user starts at a bounded workspace root.
 
@@ -96,7 +96,7 @@ Post-Phase 2 (originally tracked as no-upward-search) is complete. The planned f
 
 - [x] Phase 1 (MVP): Single-repo worktree management — create, list, remove with post-create hooks and gitignored file handling.
 - [x] Phase 2: Workspace discovery (auto-detect parent/child git repos, `workspace = true`), cross-repo `ww list` with STATUS (`active`/`merged`/`stale`), `--cleanable` filter, `ww clean`, `--repo` flag for create/remove.
-- [x] Post-Phase 2: sandbox-constrained mode for sandboxed environments (FR-26). Originally tracked as no-upward-search, and completed via the sandbox implementation. Any further sandbox refinements should be handled as separate follow-up tasks rather than this phase.
+- [x] Post-Phase 2: sandbox-constrained mode for sandboxed environments (FR-26). Originally tracked as `--no-upward-search`, and completed via the sandbox implementation. Any further sandbox refinements should be handled as separate follow-up tasks rather than this phase.
 - [x] Phase 3: Polish — shell integration (`ww cd`, `cd $(ww create feat/x)`), SemVer release automation starting at `v0.3.0`, Homebrew tap distribution, documentation.
 - [x] Phase 4: Human interactive mode — add a people-first interactive flow for common operations such as create, list, remove, clean, and worktree selection without requiring users to remember the full flag surface.
 - [ ] Phase 5 (nice-to-have): Hook trust hardening — first-run confirmation prompt, config change detection, sandbox execution, dangerous pattern warning.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/project-plan.md`
- **Issues**: N/A

## Type of Change

- [x] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `ww の project-planでPost-Phase 2を以下の記述にして、完了として。`
### Additional Context from Instructing Human

- User requested that Post-Phase 2 be marked complete using the provided wording that says the originally tracked no-upward-search follow-up landed via the sandbox implementation.
- User then asked to create the PR for that change.

## Verification

- [ ] Tests pass (command: `N/A - doc-only change`)
- [ ] Lint passes (command: `N/A - no doc-specific lint configured`)
- [x] Manual verification (describe below)

Manual verification:
- Confirmed `docs/project-plan.md` now marks Post-Phase 2 complete in both the section text and the milestone checklist.
- Reviewed the git diff to ensure the change is limited to the intended documentation update.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- Review focus: wording consistency between the Post-Phase 2 requirement text and the milestone checklist in `docs/project-plan.md`.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

- `git diff -- docs/project-plan.md`
