### PR TITLE
chore: restore gh-aw comment reviews with upsert

### DIFF
--- a/.github/workflows/impl-review.lock.yml
+++ b/.github/workflows/impl-review.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"27aa29e6d89afd9be11e03981ca3e77135ddffc567087eeb3024223eb0385e8c","compiler_version":"v0.59.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8630ad3dafe337f0105a49fb8b6e363cfad295f3ceea9d9010c4d06f96e493cc","compiler_version":"v0.59.0","strict":true}
 
 name: "Implementation Review"
 "on":
@@ -330,7 +330,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"upsert_pr_comment":{"description":"Upsert an advisory PR comment with Approve or Request Changes","inputs":{"body":{"default":null,"description":"Review comment body text (markdown)","required":true,"type":"string"},"event":{"default":null,"description":"Review event: APPROVE or REQUEST_CHANGES","options":["APPROVE","REQUEST_CHANGES"],"required":true,"type":"choice"},"pull_request_number":{"default":null,"description":"Optional PR number (defaults to the current PR)","required":false,"type":"string"}}}}
+          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"upsert_pr_comment":{"description":"Upsert an advisory PR comment with Approve or Request Changes","inputs":{"body":{"default":null,"description":"Review comment body text (markdown)","required":true,"type":"string"},"event":{"default":null,"description":"Review event: APPROVE or REQUEST_CHANGES","options":["APPROVE","REQUEST_CHANGES"],"required":true,"type":"choice"}}}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
@@ -444,10 +444,6 @@ jobs:
                       "APPROVE",
                       "REQUEST_CHANGES"
                     ],
-                    "type": "string"
-                  },
-                  "pull_request_number": {
-                    "description": "Optional PR number (defaults to the current PR)",
                     "type": "string"
                   }
                 },
@@ -987,7 +983,7 @@ jobs:
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1105,7 +1101,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Download agent output artifact
         continue-on-error: true
@@ -1130,31 +1125,11 @@ jobs:
               : Array.isArray(output?.items)
                 ? output.items
                     .filter(i => i && i.type === 'upsert_pr_comment')
-                    .map(i => ({
-                      pull_request_number: i.pull_request_number,
-                      event: i.event,
-                      body: i.body,
-                    }))
+                    .map(i => ({ event: i.event, body: i.body }))
                 : [];
             const marker = '<!-- gh-aw:impl-review -->';
             for (const item of items) {
               try {
-                const rawPullNumber = String(item.pull_request_number ?? '').trim();
-                const hasStrictOverride = /^[1-9][0-9]*$/.test(rawPullNumber);
-                const requestedPullNumber = hasStrictOverride ? Number(rawPullNumber) : null;
-                const isPullRequestEvent = context.eventName === 'pull_request';
-                if (rawPullNumber && !hasStrictOverride) {
-                  core.warning(`Ignoring invalid pull_request_number: ${JSON.stringify(rawPullNumber)}`);
-                }
-                if (isPullRequestEvent && requestedPullNumber && requestedPullNumber !== context.issue.number) {
-                  core.warning(`Ignoring pull_request_number override ${requestedPullNumber} for pull_request event #${context.issue.number}`);
-                }
-                if (!isPullRequestEvent && requestedPullNumber == null) {
-                  throw new Error('pull_request_number is required for non-pull_request events');
-                }
-                const pullNumber = isPullRequestEvent
-                  ? context.issue.number
-                  : requestedPullNumber;
                 const rawBody = String(item.body ?? '').trim();
                 const bodyWithoutMarker = rawBody.split(marker).join('').trim();
                 const bodyWithDecision = bodyWithoutMarker.includes(item.event)
@@ -1165,7 +1140,7 @@ jobs:
                 for await (const page of github.paginate.iterator(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: pullNumber,
+                  issue_number: context.issue.number,
                 })) {
                   for (const c of page.data) {
                     if (c.user && c.user.login === 'github-actions[bot]' &&
@@ -1201,7 +1176,7 @@ jobs:
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pullNumber,
+                    issue_number: context.issue.number,
                     body: commentBody
                   });
                   core.info(`Posted ${item.event} review as PR comment`);

--- a/.github/workflows/impl-review.md
+++ b/.github/workflows/impl-review.md
@@ -144,8 +144,10 @@ Provide specific, actionable feedback referencing the plan sub-tasks and spec se
 
 After making your decision, submit an advisory PR comment using the `safeoutputs-upsert_pr_comment` safe output. If your runtime exposes the tool without the prefix, call `upsert_pr_comment`.
 
+- Emit exactly one safe-output item when you can read PR content.
 - Use `event: "APPROVE"` to approve the implementation.
 - Use `event: "REQUEST_CHANGES"` to request changes.
 - Include your detailed feedback in `body`.
 - The body must include the stable marker `<!-- gh-aw:impl-review -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
+- Use `noop` only if you were completely unable to read any PR content.
 - Do not call `add_comment`.

--- a/.github/workflows/impl-review.md
+++ b/.github/workflows/impl-review.md
@@ -18,19 +18,13 @@ tools:
 network: defaults
 
 safe-outputs:
-  report-failure-as-issue: false
   jobs:
     upsert_pr_comment:
       description: "Upsert an advisory PR comment with Approve or Request Changes"
       runs-on: ubuntu-latest
       permissions:
         issues: write
-        pull-requests: write
       inputs:
-        pull_request_number:
-          description: "Optional PR number (defaults to the current PR)"
-          required: false
-          type: string
         event:
           description: "Review event: APPROVE or REQUEST_CHANGES"
           required: true
@@ -54,31 +48,11 @@ safe-outputs:
                 : Array.isArray(output?.items)
                   ? output.items
                       .filter(i => i && i.type === 'upsert_pr_comment')
-                      .map(i => ({
-                        pull_request_number: i.pull_request_number,
-                        event: i.event,
-                        body: i.body,
-                      }))
+                      .map(i => ({ event: i.event, body: i.body }))
                   : [];
               const marker = '<!-- gh-aw:impl-review -->';
               for (const item of items) {
                 try {
-                  const rawPullNumber = String(item.pull_request_number ?? '').trim();
-                  const hasStrictOverride = /^[1-9][0-9]*$/.test(rawPullNumber);
-                  const requestedPullNumber = hasStrictOverride ? Number(rawPullNumber) : null;
-                  const isPullRequestEvent = context.eventName === 'pull_request';
-                  if (rawPullNumber && !hasStrictOverride) {
-                    core.warning(`Ignoring invalid pull_request_number: ${JSON.stringify(rawPullNumber)}`);
-                  }
-                  if (isPullRequestEvent && requestedPullNumber && requestedPullNumber !== context.issue.number) {
-                    core.warning(`Ignoring pull_request_number override ${requestedPullNumber} for pull_request event #${context.issue.number}`);
-                  }
-                  if (!isPullRequestEvent && requestedPullNumber == null) {
-                    throw new Error('pull_request_number is required for non-pull_request events');
-                  }
-                  const pullNumber = isPullRequestEvent
-                    ? context.issue.number
-                    : requestedPullNumber;
                   const rawBody = String(item.body ?? '').trim();
                   const bodyWithoutMarker = rawBody.split(marker).join('').trim();
                   const bodyWithDecision = bodyWithoutMarker.includes(item.event)
@@ -89,7 +63,7 @@ safe-outputs:
                   for await (const page of github.paginate.iterator(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pullNumber,
+                    issue_number: context.issue.number,
                   })) {
                     for (const c of page.data) {
                       if (c.user && c.user.login === 'github-actions[bot]' &&
@@ -125,7 +99,7 @@ safe-outputs:
                     await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: pullNumber,
+                      issue_number: context.issue.number,
                       body: commentBody
                     });
                     core.info(`Posted ${item.event} review as PR comment`);
@@ -165,60 +139,13 @@ You are a senior engineering reviewer evaluating an implementation PR.
 - **Approve** if all plan sub-tasks are implemented, specs match code, and tests exist.
 - **Request Changes** if sub-tasks are missing, there are spec-code mismatches, or significant over-scoping.
 
+Provide specific, actionable feedback referencing the plan sub-tasks and spec sections.
 ### Submitting Your Review
 
-After making your decision, you MUST call one of the following safe outputs — producing zero output is not acceptable:
+After making your decision, submit an advisory PR comment using the `safeoutputs-upsert_pr_comment` safe output. If your runtime exposes the tool without the prefix, call `upsert_pr_comment`.
 
-- Call the safe-output tool named `safeoutputs-upsert_pr_comment` with `event: "APPROVE"` to post/update the advisory PR comment. If your runtime exposes the same tool without the `safeoutputs-` prefix, call `upsert_pr_comment`.
-- Call the safe-output tool named `safeoutputs-upsert_pr_comment` with `event: "REQUEST_CHANGES"` to post/update the advisory PR comment. If your runtime exposes the same tool without the `safeoutputs-` prefix, call `upsert_pr_comment`.
-- Call `noop` **only** if you were completely unable to read any PR content (e.g., all tool calls failed). Include a brief explanation in the message.
-
-Include your detailed feedback in the `body` field of `upsert_pr_comment`. The body MUST include the stable marker `<!-- gh-aw:impl-review -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
-Do not call `add_comment`, and do not pass `type: "upsert_pr_comment"` to `add_comment`.
-
-Provide specific, actionable feedback referencing the plan sub-tasks and spec sections.
-
-### Fallback if safe-output tools are unavailable
-
-If safe-output tool calls fail with `Tool '<name>' does not exist`, do **not** end without output.
-
-Use `shell` to write `/tmp/gh-aw/agent_output.json` directly with one item.
-
-**Important:** the file must contain valid JSON. Do **not** paste a raw multi-line review body directly into a JSON string. Review bodies often contain newlines, quotes, and Markdown, so generate the JSON with a serializer (for example `python -c` or `jq -n`) or otherwise ensure newlines are encoded as `\n` and quotes/backslashes are escaped.
-
-Example shape:
-
-```json
-{"items":[{"type":"upsert_pr_comment","event":"APPROVE","body":"<!-- gh-aw:impl-review -->\nAPPROVE\n\nLGTM. Implementation matches the plan and specs."}]}
-```
-
-If you cannot read any PR content, use `noop` instead:
-
-```json
-{"items":[{"type":"noop","message":"Unable to read PR content because required tool calls failed."}]}
-```
-
-Example using Python JSON encoding:
-
-```bash
-python - <<'PY'
-import json
-body = "LGTM. Implementation matches the plan and specs."
-obj = {"items":[{"type":"upsert_pr_comment","event":"APPROVE","body":"<!-- gh-aw:impl-review -->\nAPPROVE\n\n" + body}]}
-with open("/tmp/gh-aw/agent_output.json", "w", encoding="utf-8") as f:
-    json.dump(obj, f)
-PY
-```
-
-This is only a fallback path when the safe-output tools are unavailable.
-
-### Reading Strategy
-
-To avoid running out of context on large PRs, follow this order and stop reading once you have enough information to decide:
-
-1. Read only the plan file and `docs/spec-code-mapping.md` first.
-2. Skim the list of changed files (filenames only) to verify they match the plan's code-change table.
-3. Read the spec diff sections only (not implementation code) to check spec-code parity.
-4. If you still need more detail, read specific code files selectively.
-
-Submit your review as soon as you can make a confident decision — do not wait until you have read every line.
+- Use `event: "APPROVE"` to approve the implementation.
+- Use `event: "REQUEST_CHANGES"` to request changes.
+- Include your detailed feedback in `body`.
+- The body must include the stable marker `<!-- gh-aw:impl-review -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
+- Do not call `add_comment`.

--- a/.github/workflows/plan-review.lock.yml
+++ b/.github/workflows/plan-review.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f6969557b275a961b166e265ddc811daf6fbcaa5177e934ab8d7e9c57710679d","compiler_version":"v0.59.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7787589e20fd4bdbcf9ef2f67edccbe3b5e0d3bb13e6a1d1869fdcd9565ea423","compiler_version":"v0.59.0","strict":true}
 
 name: "Plan Review"
 "on":
@@ -330,7 +330,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"upsert_pr_comment":{"description":"Upsert an advisory PR comment with Approve or Request Changes","inputs":{"body":{"default":null,"description":"Review comment body text (markdown)","required":true,"type":"string"},"event":{"default":null,"description":"Review event: APPROVE or REQUEST_CHANGES","options":["APPROVE","REQUEST_CHANGES"],"required":true,"type":"choice"},"pull_request_number":{"default":null,"description":"Optional PR number (defaults to the current PR)","required":false,"type":"string"}}}}
+          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"upsert_pr_comment":{"description":"Upsert an advisory PR comment with Approve or Request Changes","inputs":{"body":{"default":null,"description":"Review comment body text (markdown)","required":true,"type":"string"},"event":{"default":null,"description":"Review event: APPROVE or REQUEST_CHANGES","options":["APPROVE","REQUEST_CHANGES"],"required":true,"type":"choice"}}}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
@@ -444,10 +444,6 @@ jobs:
                       "APPROVE",
                       "REQUEST_CHANGES"
                     ],
-                    "type": "string"
-                  },
-                  "pull_request_number": {
-                    "description": "Optional PR number (defaults to the current PR)",
                     "type": "string"
                   }
                 },
@@ -1105,7 +1101,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Download agent output artifact
         continue-on-error: true
@@ -1130,31 +1125,11 @@ jobs:
               : Array.isArray(output?.items)
                 ? output.items
                     .filter(i => i && i.type === 'upsert_pr_comment')
-                    .map(i => ({
-                      pull_request_number: i.pull_request_number,
-                      event: i.event,
-                      body: i.body,
-                    }))
+                    .map(i => ({ event: i.event, body: i.body }))
                 : [];
             const marker = '<!-- gh-aw:plan-review -->';
             for (const item of items) {
               try {
-                const rawPullNumber = String(item.pull_request_number ?? '').trim();
-                const hasStrictOverride = /^[1-9][0-9]*$/.test(rawPullNumber);
-                const requestedPullNumber = hasStrictOverride ? Number(rawPullNumber) : null;
-                const isPullRequestEvent = context.eventName === 'pull_request';
-                if (rawPullNumber && !hasStrictOverride) {
-                  core.warning(`Ignoring invalid pull_request_number: ${JSON.stringify(rawPullNumber)}`);
-                }
-                if (isPullRequestEvent && requestedPullNumber && requestedPullNumber !== context.issue.number) {
-                  core.warning(`Ignoring pull_request_number override ${requestedPullNumber} for pull_request event #${context.issue.number}`);
-                }
-                if (!isPullRequestEvent && requestedPullNumber == null) {
-                  throw new Error('pull_request_number is required for non-pull_request events');
-                }
-                const pullNumber = isPullRequestEvent
-                  ? context.issue.number
-                  : requestedPullNumber;
                 const rawBody = String(item.body ?? '').trim();
                 const bodyWithoutMarker = rawBody.split(marker).join('').trim();
                 const bodyWithDecision = bodyWithoutMarker.includes(item.event)
@@ -1165,7 +1140,7 @@ jobs:
                 for await (const page of github.paginate.iterator(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: pullNumber,
+                  issue_number: context.issue.number,
                 })) {
                   for (const c of page.data) {
                     if (c.user && c.user.login === 'github-actions[bot]' &&
@@ -1201,7 +1176,7 @@ jobs:
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pullNumber,
+                    issue_number: context.issue.number,
                     body: commentBody
                   });
                   core.info(`Posted ${item.event} review as PR comment`);

--- a/.github/workflows/plan-review.md
+++ b/.github/workflows/plan-review.md
@@ -22,12 +22,7 @@ safe-outputs:
       runs-on: ubuntu-latest
       permissions:
         issues: write
-        pull-requests: write
       inputs:
-        pull_request_number:
-          description: "Optional PR number (defaults to the current PR)"
-          required: false
-          type: string
         event:
           description: "Review event: APPROVE or REQUEST_CHANGES"
           required: true
@@ -51,31 +46,11 @@ safe-outputs:
                 : Array.isArray(output?.items)
                   ? output.items
                       .filter(i => i && i.type === 'upsert_pr_comment')
-                      .map(i => ({
-                        pull_request_number: i.pull_request_number,
-                        event: i.event,
-                        body: i.body,
-                      }))
+                      .map(i => ({ event: i.event, body: i.body }))
                   : [];
               const marker = '<!-- gh-aw:plan-review -->';
               for (const item of items) {
                 try {
-                  const rawPullNumber = String(item.pull_request_number ?? '').trim();
-                  const hasStrictOverride = /^[1-9][0-9]*$/.test(rawPullNumber);
-                  const requestedPullNumber = hasStrictOverride ? Number(rawPullNumber) : null;
-                  const isPullRequestEvent = context.eventName === 'pull_request';
-                  if (rawPullNumber && !hasStrictOverride) {
-                    core.warning(`Ignoring invalid pull_request_number: ${JSON.stringify(rawPullNumber)}`);
-                  }
-                  if (isPullRequestEvent && requestedPullNumber && requestedPullNumber !== context.issue.number) {
-                    core.warning(`Ignoring pull_request_number override ${requestedPullNumber} for pull_request event #${context.issue.number}`);
-                  }
-                  if (!isPullRequestEvent && requestedPullNumber == null) {
-                    throw new Error('pull_request_number is required for non-pull_request events');
-                  }
-                  const pullNumber = isPullRequestEvent
-                    ? context.issue.number
-                    : requestedPullNumber;
                   const rawBody = String(item.body ?? '').trim();
                   const bodyWithoutMarker = rawBody.split(marker).join('').trim();
                   const bodyWithDecision = bodyWithoutMarker.includes(item.event)
@@ -86,7 +61,7 @@ safe-outputs:
                   for await (const page of github.paginate.iterator(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pullNumber,
+                    issue_number: context.issue.number,
                   })) {
                     for (const c of page.data) {
                       if (c.user && c.user.login === 'github-actions[bot]' &&
@@ -122,7 +97,7 @@ safe-outputs:
                     await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: pullNumber,
+                      issue_number: context.issue.number,
                       body: commentBody
                     });
                     core.info(`Posted ${item.event} review as PR comment`);
@@ -158,59 +133,13 @@ You are a senior engineering reviewer evaluating an execution plan PR.
 - **Approve** if all criteria are met or any gaps are minor.
 - **Request Changes** if the plan is missing critical information (problem statement, spec changes, or sub-tasks), the scope is clearly wrong, or dependencies are missing that would cause implementation failures.
 
+Provide specific, actionable feedback. Reference the exact sections that need improvement.
 ### Submitting Your Review
 
-After making your decision, you MUST call one of the following safe outputs — producing zero output is not acceptable:
+After making your decision, submit an advisory PR comment using the `safeoutputs-upsert_pr_comment` safe output. If your runtime exposes the tool without the prefix, call `upsert_pr_comment`.
 
-- Call the safe-output tool named `safeoutputs-upsert_pr_comment` with `event: "APPROVE"` to post/update the advisory PR comment. If your runtime exposes the same tool without the `safeoutputs-` prefix, call `upsert_pr_comment`.
-- Call the safe-output tool named `safeoutputs-upsert_pr_comment` with `event: "REQUEST_CHANGES"` to post/update the advisory PR comment. If your runtime exposes the same tool without the `safeoutputs-` prefix, call `upsert_pr_comment`.
-- Call `noop` **only** if you were completely unable to read any PR content (e.g., all tool calls failed). Include a brief explanation in the message.
-
-Include your detailed feedback in the `body` field of `upsert_pr_comment`. The body MUST include the stable marker `<!-- gh-aw:plan-review -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
-Do not call `add_comment`, and do not pass `type: "upsert_pr_comment"` to `add_comment`.
-
-Provide specific, actionable feedback. Reference the exact sections that need improvement.
-
-### Fallback if safe-output tools are unavailable
-
-If safe-output tool calls fail with `Tool "<name>" does not exist` (or the same message with single quotes, `Tool '<name>' does not exist`), do **not** end without output.
-
-Use `shell` to write `/tmp/gh-aw/agent_output.json` directly with exactly one item in the `items` array.
-
-**Important:** the file must contain valid JSON. Do **not** paste a raw multi-line review body directly into a JSON string. Review bodies often contain newlines, quotes, and Markdown, so generate the JSON with a serializer (for example `python -` with a heredoc or `jq -n`) or otherwise ensure newlines are encoded as `\n` and quotes/backslashes are escaped.
-
-This is only a fallback path when the safe-output tools are unavailable.
-
-Example shape:
-
-```json
-{"items":[{"type":"upsert_pr_comment","event":"APPROVE","body":"<!-- gh-aw:plan-review -->\nAPPROVE\n\nLGTM. Plan is complete and actionable."}]}
-```
-
-If you cannot read any PR content, use `noop` instead:
-
-```json
-{"items":[{"type":"noop","message":"Unable to read PR content because required tool calls failed."}]}
-```
-
-Example using Python JSON encoding:
-
-```bash
-python - <<'PY'
-import json
-body = "LGTM. Plan is complete and actionable."
-obj = {"items":[{"type":"upsert_pr_comment","event":"APPROVE","body":"<!-- gh-aw:plan-review -->\nAPPROVE\n\n" + body}]}
-with open("/tmp/gh-aw/agent_output.json", "w", encoding="utf-8") as f:
-    json.dump(obj, f)
-PY
-```
-
-### Reading Strategy
-
-To avoid running out of context on large PRs, follow this order and stop reading once you have enough information to decide whether the plan meets the review criteria (problem statement, spec changes, concrete sub-tasks, and dependencies):
-
-1. Read only changed files under `docs/exec-plan/todo/` first.
-2. If needed, read referenced issue files under `docs/issues/` for context.
-3. Skim only filenames of other changed files to confirm scope is plan-only.
-
-Submit your review as soon as you can make a confident decision — do not wait until you have read every line.
+- Use `event: "APPROVE"` to approve the plan.
+- Use `event: "REQUEST_CHANGES"` to request changes.
+- Include your detailed feedback in `body`.
+- The body must include the stable marker `<!-- gh-aw:plan-review -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
+- Do not call `add_comment`.

--- a/.github/workflows/plan-review.md
+++ b/.github/workflows/plan-review.md
@@ -138,8 +138,10 @@ Provide specific, actionable feedback. Reference the exact sections that need im
 
 After making your decision, submit an advisory PR comment using the `safeoutputs-upsert_pr_comment` safe output. If your runtime exposes the tool without the prefix, call `upsert_pr_comment`.
 
+- Emit exactly one safe-output item when you can read PR content.
 - Use `event: "APPROVE"` to approve the plan.
 - Use `event: "REQUEST_CHANGES"` to request changes.
 - Include your detailed feedback in `body`.
 - The body must include the stable marker `<!-- gh-aw:plan-review -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
+- Use `noop` only if you were completely unable to read any PR content.
 - Do not call `add_comment`.

--- a/.github/workflows/spec-code-sync.lock.yml
+++ b/.github/workflows/spec-code-sync.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3011acd2cea74495fd165941d91c4bc09b1655faf8d93637f0d37808a3ac99d8","compiler_version":"v0.59.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"47f11897ef05aa93a1badad338c161d6656c6ea356c9ad3810a1a99cd542d0b1","compiler_version":"v0.59.0","strict":true}
 
 name: "Spec/Code Sync Check"
 "on":
@@ -335,7 +335,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"upsert_pr_comment":{"description":"Upsert an advisory PR comment with Approve or Request Changes","inputs":{"body":{"default":null,"description":"Review comment body text (markdown)","required":true,"type":"string"},"event":{"default":null,"description":"Review event: APPROVE or REQUEST_CHANGES","options":["APPROVE","REQUEST_CHANGES"],"required":true,"type":"choice"},"pull_request_number":{"default":null,"description":"Optional PR number (defaults to the current PR)","required":false,"type":"string"}}}}
+          {"missing_data":{},"missing_tool":{},"noop":{"max":1},"upsert_pr_comment":{"description":"Upsert an advisory PR comment with Approve or Request Changes","inputs":{"body":{"default":null,"description":"Review comment body text (markdown)","required":true,"type":"string"},"event":{"default":null,"description":"Review event: APPROVE or REQUEST_CHANGES","options":["APPROVE","REQUEST_CHANGES"],"required":true,"type":"choice"}}}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
@@ -449,10 +449,6 @@ jobs:
                       "APPROVE",
                       "REQUEST_CHANGES"
                     ],
-                    "type": "string"
-                  },
-                  "pull_request_number": {
-                    "description": "Optional PR number (defaults to the current PR)",
                     "type": "string"
                   }
                 },
@@ -1110,7 +1106,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Download agent output artifact
         continue-on-error: true
@@ -1135,31 +1130,11 @@ jobs:
               : Array.isArray(output?.items)
                 ? output.items
                     .filter(i => i && i.type === 'upsert_pr_comment')
-                    .map(i => ({
-                      pull_request_number: i.pull_request_number,
-                      event: i.event,
-                      body: i.body,
-                    }))
+                    .map(i => ({ event: i.event, body: i.body }))
                 : [];
             const marker = '<!-- gh-aw:spec-code-sync -->';
             for (const item of items) {
               try {
-                const rawPullNumber = String(item.pull_request_number ?? '').trim();
-                const hasStrictOverride = /^[1-9][0-9]*$/.test(rawPullNumber);
-                const requestedPullNumber = hasStrictOverride ? Number(rawPullNumber) : null;
-                const isPullRequestEvent = context.eventName === 'pull_request';
-                if (rawPullNumber && !hasStrictOverride) {
-                  core.warning(`Ignoring invalid pull_request_number: ${JSON.stringify(rawPullNumber)}`);
-                }
-                if (isPullRequestEvent && requestedPullNumber && requestedPullNumber !== context.issue.number) {
-                  core.warning(`Ignoring pull_request_number override ${requestedPullNumber} for pull_request event #${context.issue.number}`);
-                }
-                if (!isPullRequestEvent && requestedPullNumber == null) {
-                  throw new Error('pull_request_number is required for non-pull_request events');
-                }
-                const pullNumber = isPullRequestEvent
-                  ? context.issue.number
-                  : requestedPullNumber;
                 const rawBody = String(item.body ?? '').trim();
                 const bodyWithoutMarker = rawBody.split(marker).join('').trim();
                 const bodyWithDecision = bodyWithoutMarker.includes(item.event)
@@ -1170,7 +1145,7 @@ jobs:
                 for await (const page of github.paginate.iterator(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: pullNumber,
+                  issue_number: context.issue.number,
                 })) {
                   for (const c of page.data) {
                     if (c.user && c.user.login === 'github-actions[bot]' &&
@@ -1206,7 +1181,7 @@ jobs:
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pullNumber,
+                    issue_number: context.issue.number,
                     body: commentBody
                   });
                   core.info(`Posted ${item.event} review as PR comment`);

--- a/.github/workflows/spec-code-sync.md
+++ b/.github/workflows/spec-code-sync.md
@@ -148,8 +148,10 @@ Be precise. Reference the specific spec section and code file that are out of sy
 
 After making your decision, submit an advisory PR comment using the `safeoutputs-upsert_pr_comment` safe output. If your runtime exposes the tool without the prefix, call `upsert_pr_comment`.
 
+- Emit exactly one safe-output item when you can read PR content.
 - Use `event: "APPROVE"` to approve the PR.
 - Use `event: "REQUEST_CHANGES"` to request changes.
 - Include your detailed feedback in `body`.
 - The body must include the stable marker `<!-- gh-aw:spec-code-sync -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
+- Use `noop` only if you were completely unable to read any PR content.
 - Do not call `add_comment`.

--- a/.github/workflows/spec-code-sync.md
+++ b/.github/workflows/spec-code-sync.md
@@ -27,12 +27,7 @@ safe-outputs:
       runs-on: ubuntu-latest
       permissions:
         issues: write
-        pull-requests: write
       inputs:
-        pull_request_number:
-          description: "Optional PR number (defaults to the current PR)"
-          required: false
-          type: string
         event:
           description: "Review event: APPROVE or REQUEST_CHANGES"
           required: true
@@ -56,31 +51,11 @@ safe-outputs:
                 : Array.isArray(output?.items)
                   ? output.items
                       .filter(i => i && i.type === 'upsert_pr_comment')
-                      .map(i => ({
-                        pull_request_number: i.pull_request_number,
-                        event: i.event,
-                        body: i.body,
-                      }))
+                      .map(i => ({ event: i.event, body: i.body }))
                   : [];
               const marker = '<!-- gh-aw:spec-code-sync -->';
               for (const item of items) {
                 try {
-                  const rawPullNumber = String(item.pull_request_number ?? '').trim();
-                  const hasStrictOverride = /^[1-9][0-9]*$/.test(rawPullNumber);
-                  const requestedPullNumber = hasStrictOverride ? Number(rawPullNumber) : null;
-                  const isPullRequestEvent = context.eventName === 'pull_request';
-                  if (rawPullNumber && !hasStrictOverride) {
-                    core.warning(`Ignoring invalid pull_request_number: ${JSON.stringify(rawPullNumber)}`);
-                  }
-                  if (isPullRequestEvent && requestedPullNumber && requestedPullNumber !== context.issue.number) {
-                    core.warning(`Ignoring pull_request_number override ${requestedPullNumber} for pull_request event #${context.issue.number}`);
-                  }
-                  if (!isPullRequestEvent && requestedPullNumber == null) {
-                    throw new Error('pull_request_number is required for non-pull_request events');
-                  }
-                  const pullNumber = isPullRequestEvent
-                    ? context.issue.number
-                    : requestedPullNumber;
                   const rawBody = String(item.body ?? '').trim();
                   const bodyWithoutMarker = rawBody.split(marker).join('').trim();
                   const bodyWithDecision = bodyWithoutMarker.includes(item.event)
@@ -91,7 +66,7 @@ safe-outputs:
                   for await (const page of github.paginate.iterator(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: pullNumber,
+                    issue_number: context.issue.number,
                   })) {
                     for (const c of page.data) {
                       if (c.user && c.user.login === 'github-actions[bot]' &&
@@ -127,7 +102,7 @@ safe-outputs:
                     await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: pullNumber,
+                      issue_number: context.issue.number,
                       body: commentBody
                     });
                     core.info(`Posted ${item.event} review as PR comment`);
@@ -168,45 +143,13 @@ You are a reviewer checking spec-code synchronization.
 - **Approve** if specs and code are in sync, or if changes are purely internal/clarification.
 - **Request Changes** if there is a clear mismatch between spec and code behavior.
 
+Be precise. Reference the specific spec section and code file that are out of sync.
 ### Submitting Your Review
 
-After making your decision, you MUST call one of the following safe outputs — producing zero output is not acceptable:
+After making your decision, submit an advisory PR comment using the `safeoutputs-upsert_pr_comment` safe output. If your runtime exposes the tool without the prefix, call `upsert_pr_comment`.
 
-- Call the safe-output tool named `safeoutputs-upsert_pr_comment` with `event: "APPROVE"` to post/update the advisory PR comment. If your runtime exposes the same tool without the `safeoutputs-` prefix, call `upsert_pr_comment`.
-- Call the safe-output tool named `safeoutputs-upsert_pr_comment` with `event: "REQUEST_CHANGES"` to post/update the advisory PR comment. If your runtime exposes the same tool without the `safeoutputs-` prefix, call `upsert_pr_comment`.
-- Call `noop` **only** if you were completely unable to read any PR content (e.g., all tool calls failed). Include a brief explanation in the message.
-
-Include your detailed feedback in the `body` field of `upsert_pr_comment`. The body MUST include the stable marker `<!-- gh-aw:spec-code-sync -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
-Do not call `add_comment`, and do not pass `type: "upsert_pr_comment"` to `add_comment`.
-
-Be precise. Reference the specific spec section and code file that are out of sync.
-
-### Fallback if safe-output tools are unavailable
-
-If safe-output tool calls fail with `Tool '<name>' does not exist`, do **not** end without output.
-
-Use `shell` to write `/tmp/gh-aw/agent_output.json` directly with one item.
-
-**Important:** the file must contain valid JSON. Do **not** paste a raw multi-line review body directly into a JSON string. Review bodies often contain newlines, quotes, and Markdown, so generate the JSON with a serializer (for example `python -c` or `jq -n`) or otherwise ensure newlines are encoded as `\n` and quotes/backslashes are escaped.
-
-Example shape:
-
-```json
-{"items":[{"type":"upsert_pr_comment","event":"APPROVE","body":"<!-- gh-aw:spec-code-sync -->\nAPPROVE\n\nSpecs and code are in sync."}]}
-```
-
-If you cannot read any PR content, use `noop` instead:
-
-```json
-{"items":[{"type":"noop","message":"Unable to read PR content because required tool calls failed."}]}
-```
-
-### Reading Strategy
-
-To avoid running out of context on large PRs, follow this order and stop reading once you have enough information to decide:
-
-1. Read `docs/spec-code-mapping.md` and the list of changed files (filenames only) first.
-2. Read the spec diff sections only (not implementation code) to check spec-code parity.
-3. If you still need more detail, read specific code files selectively.
-
-Submit your review as soon as you can make a confident decision — do not wait until you have read every line.
+- Use `event: "APPROVE"` to approve the PR.
+- Use `event: "REQUEST_CHANGES"` to request changes.
+- Include your detailed feedback in `body`.
+- The body must include the stable marker `<!-- gh-aw:spec-code-sync -->` and a visible `APPROVE` or `REQUEST_CHANGES` decision label.
+- Do not call `add_comment`.

--- a/docs/specs/agentic-review-workflows.md
+++ b/docs/specs/agentic-review-workflows.md
@@ -16,9 +16,6 @@ Each workflow must define a custom safe-output job that upserts a PR issue comme
 
 - `event`: either `APPROVE` or `REQUEST_CHANGES`
 - `body`: markdown review feedback
-- `pull_request_number`: optional positive integer override for non-`pull_request` events
-
-For `pull_request` events, the current event PR number is authoritative. Invalid overrides are ignored with a warning. Overrides that do not match the current PR are ignored with a warning. For non-`pull_request` events, a valid positive-integer `pull_request_number` is required; the job must fail early with a clear error when it is missing or invalid instead of falling through to an undefined issue number.
 
 ## Markers
 
@@ -45,7 +42,7 @@ The safe-output job must:
 
 Comment deletion failures are non-fatal and must be emitted as warnings.
 
-The job must request `issues: write` and `pull-requests: write` permissions so PR issue comments can be created and updated consistently. The `pull-requests: write` permission is only for PR-comment workflow compatibility; the job must still avoid formal PR review APIs.
+The job must request `issues: write` permission so PR issue comments can be created and updated consistently.
 
 Verification for this spec is `gh aw compile --strict` for the three covered workflows, plus a stale-token search that confirms the current workflow sources and lock files do not contain legacy formal-review output names or Pull Requests review API calls.
 
@@ -72,5 +69,3 @@ Each prompt must require the agent to produce exactly one review-comment safe ou
 The prompt must identify the custom safe-output tool by the runtime-visible tool name `safeoutputs-upsert_pr_comment`, while also allowing the unqualified `upsert_pr_comment` name when a runtime exposes it that way. The prompt must explicitly tell agents not to use the built-in add-comment tool for this output.
 
 The agent may call `noop` only when it is completely unable to read PR content.
-
-Fallback instructions for missing safe-output tools must write `/tmp/gh-aw/agent_output.json` with exactly one comment-upsert item. The fallback JSON must use serialized strings so markdown, quotes, and newlines are valid JSON.


### PR DESCRIPTION
## Plan / Issues
- Human-requested workflow rollback for `gh aw` review workflows in `ww`
- Restore behavior close to `6880e8ab4f10ec8535fd5b79ea517d52731ed952`
- Keep only the comment upsert behavior derived from `09b830a5d446d3861d03e5d5495384eec55e7904`

## Type of Change
- [x] Chore / CI / workflow maintenance
- [ ] Feature
- [ ] Bug fix
- [ ] Docs only

## Instructions
- Restore the three gh-aw review workflows to the original comment-oriented prompts and structure.
- Do not keep the later formal PR review submission flow.
- Preserve only the behavior that updates the existing bot comment instead of always posting a new one.

### Additional Context from Instructing Human
- The recent safe-output related patches left the workflows in a state where they no longer reliably comment on PRs.
- The desired target is the initial state from `6880e8ab4f10ec8535fd5b79ea517d52731ed952` plus only the prior-comment overwrite behavior, likely from `09b830a5d446d3861d03e5d5495384eec55e7904`.
- I also reviewed later commits and intentionally did not keep the prompt-hardening/fallback changes in this PR so the rollback stays narrow.

## Verification
- [x] `gh aw compile --strict plan-review impl-review spec-code-sync`
- [x] `make lint`
- [x] `make test`
- [ ] `make test-all` (did not complete within the current sandbox session; no workflow/code failures from this change were observed before it stalled)

## Checklist
- [x] Branch type matches scope (`chore/*`)
- [x] Spec updated to match behavior
- [x] Generated lock files regenerated
- [x] Diff scoped to workflow/spec files only

## Dependencies
- N/A

## Reviewer Notes
- This intentionally removes the later `submit_pr_review` / safe-output fallback / prompt-hardening layers and keeps only advisory PR comment upsert behavior.
- Follow-up candidates if needed after confirming comments work again: `425bd48`, `52d1f25`, `89cf586`, `e6ecd04`, `3ce53bb`.

## Links
- `6880e8ab4f10ec8535fd5b79ea517d52731ed952`
- `09b830a5d446d3861d03e5d5495384eec55e7904`
