### PR TITLE
docs: close ww cd worktree lookup issue

### DIFF
--- a/docs/issues/done/ww-cd-cannot-find-just-created-worktree.md
+++ b/docs/issues/done/ww-cd-cannot-find-just-created-worktree.md
@@ -25,3 +25,14 @@ The original dogfooding report was first captured in:
 - `vibe-coding-workspace/docs/issues/ww-cd-cannot-find-just-created-worktree.md`
 
 That workspace issue should be treated as the source report. This `ww` issue tracks the product-side investigation and fix work inside the `ww` repository.
+
+## Resolution
+
+Resolved on `main` by the workspace-root parity fix and regression coverage:
+
+- `720ab5d` `fix: cover git-backed workspace-root create/cd parity (#213)`
+- `integration_test.go`: `TestCdFindsJustCreatedWorktreeFromGitBackedWorkspaceRoot`
+
+Verification:
+
+- `go test -C ww ./... -run TestCdFindsJustCreatedWorktreeFromGitBackedWorkspaceRoot -count=1`


### PR DESCRIPTION
## Plan / Issues

- **Plan**: N/A
- **Issues**: `docs/issues/ww-cd-cannot-find-just-created-worktree.md`

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `$plan-execution ww/docs/issues/ww-cd-cannot-find-just-created-worktree.md が修正済みか確認。修正されていなければ解消planを作成。 vibe-coding-workspace/docs/issues/ww-cd-cannot-find-just-created-worktree.mdも一緒に完了にすることを忘れずに。`
### Additional Context from Instructing Human

- Confirm whether the `ww` issue is already fixed before creating any new plan.
- If already fixed, complete both the `ww` issue and the workspace follow-up issue together.

## Verification

- [x] Tests pass (command: `go test -C ww ./... -run TestCdFindsJustCreatedWorktreeFromGitBackedWorkspaceRoot -count=1`)
- [ ] Lint passes (command: `N/A`)
- [x] Manual verification (describe below)

Manual verification:
- Confirmed `ww` `main` already contains fix commit `720ab5d` and the completed exec plan `docs/exec-plan/done/cd-cannot-find-just-created-worktree.md`.
- Confirmed specs still describe the expected workspace-root `ww create` / `ww cd` parity behavior.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

- Related workspace follow-up PR in `vibe-coding-workspace`: closes the source report after verifying this repo-side fix.

## Reviewer Notes

- This PR does not change behavior; it closes the repo-local issue after verifying the fix already landed on `main`.

## Links

- Source follow-up issue: `vibe-coding-workspace/docs/issues/ww-cd-cannot-find-just-created-worktree.md`
- Fix commit: `720ab5d`

## Breaking Changes

N/A
