### PR TITLE
chore: roll out pinact for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
       - run: make lint

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install gh-aw extension
         uses: github/gh-aw-actions/setup-cli@066087f607f52664010289ddd52198f33044c38a # v0.59.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,11 @@ Three workflows automatically review PRs: `plan-review`, `impl-review`, `spec-co
 - Log each false positive as a `docs/issues/` entry describing the trigger and why it was wrong
 - Use logged false positives to refine the workflow prompts in `.github/workflows/*.md`
 
+## GitHub Actions Pinning
+
+- When editing ordinary GitHub Actions workflows or composite actions, use `pinact` to pin or update `uses:` references rather than hand-editing version tags.
+- Do not run `pinact` on `gh aw` source workflows (`.github/workflows/*.md`), generated `.lock.yml` files, or `.github/aw/actions-lock.json`.
+
 ## Lessons Learned
 
 - **Always pull before pushing on CI-active branches**: Agentic workflows may push commits (e.g., automated fixes) between your commits. Always `git pull --rebase` before pushing to avoid rejected pushes and merge conflicts.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,5 +11,5 @@ Detailed specifications for `ww` CLI behavior.
 | [shell-integration.md](shell-integration.md) | `ww cd`, `ww create -q`, and shell wrapper patterns |
 | [interactive-mode.md](interactive-mode.md) | Human-oriented `ww i` flows for create, list, open, remove, and clean |
 | [release-versioning.md](release-versioning.md) | SemVer tagging, build metadata, and release automation |
-| [github-actions-pinning.md](github-actions-pinning.md) | `pinact` で普通の workflow YAML の `uses:` を管理する契約 |
+| [github-actions-pinning.md](github-actions-pinning.md) | Contract for managing ordinary workflow YAML `uses:` references with `pinact` |
 | [testing.md](testing.md) | Testing strategy and test utilities |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,4 +11,5 @@ Detailed specifications for `ww` CLI behavior.
 | [shell-integration.md](shell-integration.md) | `ww cd`, `ww create -q`, and shell wrapper patterns |
 | [interactive-mode.md](interactive-mode.md) | Human-oriented `ww i` flows for create, list, open, remove, and clean |
 | [release-versioning.md](release-versioning.md) | SemVer tagging, build metadata, and release automation |
+| [github-actions-pinning.md](github-actions-pinning.md) | `pinact` で普通の workflow YAML の `uses:` を管理する契約 |
 | [testing.md](testing.md) | Testing strategy and test utilities |

--- a/docs/specs/github-actions-pinning.md
+++ b/docs/specs/github-actions-pinning.md
@@ -1,0 +1,10 @@
+# GitHub Actions Pinning
+
+Ordinary GitHub Actions workflow files and composite actions in this repository must manage `uses:` references through `pinact`.
+
+## Operator Contract
+
+- When editing in-scope `.github/workflows/*.yml` files or `.github/actions/**`, use `pinact` to pin new `uses:` references and to update existing pinned references.
+- Do not hand-edit floating version tags such as `@v6` when the change is intended to pin or refresh an action dependency; run `pinact` instead and review the resulting diff.
+- `gh aw` source workflows (`.github/workflows/*.md`), generated lock files (`.github/workflows/*.lock.yml`), and `.github/aw/actions-lock.json` are out of scope for `pinact` and must continue to follow the `gh aw` toolchain instead.
+- It is acceptable to scope a rollout by passing explicit file paths to `pinact run` so only ordinary workflow YAML files are updated.

--- a/docs/specs/github-actions-pinning.md
+++ b/docs/specs/github-actions-pinning.md
@@ -4,7 +4,7 @@ Ordinary GitHub Actions workflow files and composite actions in this repository 
 
 ## Operator Contract
 
-- When editing in-scope `.github/workflows/*.yml` files or `.github/actions/**`, use `pinact` to pin new `uses:` references and to update existing pinned references.
+- When editing ordinary workflow YAML files under `.github/workflows/` excluding `*.lock.yml`, or when editing `.github/actions/**`, use `pinact` to pin new `uses:` references and to update existing pinned references.
 - Do not hand-edit floating version tags such as `@v6` when the change is intended to pin or refresh an action dependency; run `pinact` instead and review the resulting diff.
 - `gh aw` source workflows (`.github/workflows/*.md`), generated lock files (`.github/workflows/*.lock.yml`), and `.github/aw/actions-lock.json` are out of scope for `pinact` and must continue to follow the `gh aw` toolchain instead.
 - It is acceptable to scope a rollout by passing explicit file paths to `pinact run` so only ordinary workflow YAML files are updated.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: N/A
- **Issues**: `docs/issues/interactive-pty-smoke-timeout.md` remains open

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [x] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `docs/exec-plan/todo/pinact-rollout.md $execute-task 実行`
### Additional Context from Instructing Human

- This repository is part of the workspace-wide `pinact` rollout.
- `gh aw` source/lock files remain out of scope for this branch.

## Verification

- [ ] Tests pass (command: `make test-all` did not complete within the local verification budget; existing timeout issue remains open)
- [x] Lint passes (command: `make lint`)
- [x] Manual verification (reviewed `pinact` diffs for ordinary workflow YAML files and confirmed `gh aw` files were untouched)

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo` to `done` — _if executing a plan_
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [ ] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- This PR intentionally excludes `.github/workflows/*.md`, `.lock.yml`, and `.github/aw/actions-lock.json`.

## Links

N/A

## Breaking Changes

N/A
