### PR TITLE
plan: add gh-aw removal plan

### DIFF
--- a/docs/exec-plan/todo/remove-gh-agentic-workflow.md
+++ b/docs/exec-plan/todo/remove-gh-agentic-workflow.md
@@ -24,6 +24,7 @@ Past decisions reviewed before planning:
 Update the specs and durable docs so they describe the post-removal state accurately:
 
 - remove or retire `docs/specs/agentic-review-workflows.md`
+- update `docs/spec-code-mapping.md` so it no longer maps removed `gh aw` workflow assets to the retired spec surface
 - update `docs/specs/github-actions-pinning.md` so it no longer treats `gh aw` review workflow sources and generated lock files as active repo assets that must be preserved
 - update `AGENTS.md` to remove the `gh-aw` automated review section and any workflow-editing guidance that becomes stale after removal
 - update any remaining durable docs that still instruct contributors to maintain or regenerate these workflows
@@ -36,6 +37,7 @@ Remove the workflow assets and supporting repository metadata for the current `g
 - delete `.github/workflows/impl-review.md`
 - delete `.github/workflows/spec-code-sync.md`
 - delete the generated lock files for those workflows
+- delete `.github/aw/actions-lock.json` if the inventory confirms it is only retained for this `gh aw` review workflow line
 - remove any now-unused `gh aw` repository assets that only exist to support these review workflows, if confirmed unused after a repo-wide sweep
 - update any remaining GitHub-side workflow/config references that assume these review checks still exist
 

--- a/docs/exec-plan/todo/remove-gh-agentic-workflow.md
+++ b/docs/exec-plan/todo/remove-gh-agentic-workflow.md
@@ -1,0 +1,72 @@
+# Remove gh-aw Agentic Workflow
+**Execution**: Use `/execute-task` to implement this plan.
+
+## Objective
+
+Remove the current `gh aw`-based PR review workflow stack from `ww` so the repository stops carrying unreliable advisory automation and unnecessary CI failure noise.
+
+This plan only covers removal of the current workflow line and the supporting repository documentation/spec updates. It does not decide how or whether agentic review automation should be reintroduced later.
+
+## Context
+
+- `ww` currently carries three `gh aw` review workflows: `plan-review`, `impl-review`, and `spec-code-sync`.
+- The current line has unresolved runtime and permission issues recorded in local issue docs such as `docs/issues/gh-aw-custom-safe-output-not-emitted.md` and `docs/issues/plan-review-upsert-pr-comment-permission.md`.
+- The operator decision for this plan is to remove the current workflows now rather than continue paying CI noise and maintenance cost for unreliable review automation.
+
+Past decisions reviewed before planning:
+
+- `docs/project-plan.md`: `ww` values fast, portable, agent-friendly workflows, but that does not require keeping CI-side agentic review when it is no longer reliable.
+- `docs/design-decisions/core-beliefs.md`: correctness and explicit workflow contracts matter more than preserving an unstable automation path.
+- `docs/design-decisions/adr.md`: no existing ADR requires these review workflows to remain present, so removal can be handled as a focused workflow/spec change unless execution uncovers a broader policy decision.
+
+## Spec Changes
+
+Update the specs and durable docs so they describe the post-removal state accurately:
+
+- remove or retire `docs/specs/agentic-review-workflows.md`
+- update `docs/specs/github-actions-pinning.md` so it no longer treats `gh aw` review workflow sources and generated lock files as active repo assets that must be preserved
+- update `AGENTS.md` to remove the `gh-aw` automated review section and any workflow-editing guidance that becomes stale after removal
+- update any remaining durable docs that still instruct contributors to maintain or regenerate these workflows
+
+## Code and Repository Changes
+
+Remove the workflow assets and supporting repository metadata for the current `gh aw` review setup:
+
+- delete `.github/workflows/plan-review.md`
+- delete `.github/workflows/impl-review.md`
+- delete `.github/workflows/spec-code-sync.md`
+- delete the generated lock files for those workflows
+- remove any now-unused `gh aw` repository assets that only exist to support these review workflows, if confirmed unused after a repo-wide sweep
+- update any remaining GitHub-side workflow/config references that assume these review checks still exist
+
+## Sub-tasks
+
+- [ ] [parallel] Inventory every repo file that still references the `gh aw` review workflows or their generated artifacts.
+- [ ] [parallel] Decide the durable documentation state after removal: delete the dedicated spec, or replace it with a short note that the repository currently has no agentic PR review workflows.
+- [ ] [depends on: inventory] Update specs and durable docs to describe the removed state before touching workflow files.
+- [ ] [depends on: inventory] Remove the three source workflows, their generated lock files, and any now-dead support assets that are confirmed exclusive to this workflow line.
+- [ ] [depends on: spec/doc updates, workflow removal] Run repo verification for the docs/workflow diff and confirm no stale `gh aw` review references remain in active files.
+
+## Design Decisions
+
+- Keep the scope narrow: this plan removes the current workflow line; it does not redesign CI review automation.
+- Do not auto-close the broader reintroduction discussion when this removal lands. Choosing a future backend agent and CI credential model remains separate follow-up work.
+- Prefer deleting stale workflow-specific docs over leaving speculative “temporary disable” wording behind, unless execution finds a repo convention that requires an explicit historical note.
+
+## Parallelism
+
+- The inventory sweep and the durable-doc-state decision can happen in parallel.
+- Workflow file removal depends on the inventory sweep so we do not leave behind broken references.
+- Verification depends on both the doc/spec updates and the actual asset removal.
+
+## Verification
+
+- `make lint`
+- `rg -n "gh aw|gh-aw|agentic review|plan-review|impl-review|spec-code-sync" .github docs AGENTS.md README.md`
+- any repo-specific workflow/documentation checks needed after the final diff is known
+
+## Out of Scope
+
+- deciding which backend AI agent or API key model to use for any future CI review automation
+- replacing the removed workflows with Codex-, Copilot-, or API-key-based alternatives in the same PR
+- resolving the broader product/operations question of whether `ww` should have agentic PR review automation at all


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/todo/remove-gh-agentic-workflow.md`
- **Issues**: `#231` remains open: this PR adds the removal plan only, and does not decide the backend agent / contract / API key model for any future reintroduction.

## Type of Change

- [ ] Project Plan update
- [x] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `/plan-execution docs/exec-plan/todo/remove-gh-agentic-workflow.md`

### Additional Context from Instructing Human

- The user wants the current `ww` `gh aw` review workflow line removed because it has become unstable, no longer behaves as expected, and leaves unnecessary CI failures that now mostly function as noise.
- This line started as a `gh aw` trial, but the team has already adapted to reviewing without it, so keeping it enabled no longer has enough value.
- The user explicitly corrected the issue/plan relationship: issue `#231` should remain separate from the removal plan because removing the workflows does not resolve the future reintroduction decision.
- If agentic CI review is ever reconsidered, the unresolved question is which AI agent backend and which contract / API key model should fund and authorize that CI usage.

## Verification

- [ ] Tests pass (command: `N/A - docs-only planning change`)
- [ ] Lint passes (command: `N/A - no repo doc linter for this change`)
- [x] Manual verification (describe below)

Manual verification:

- confirmed the new plan matches the branch name and lives under `docs/exec-plan/todo/`
- confirmed the plan keeps reintroduction decisions out of scope and does not treat issue `#231` as resolved work
- checked staged diff formatting with `git diff --cached --check`

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

- GitHub issue `#231` remains open by design for future backend-agent / credential-model decisions.

## Reviewer Notes

- Please review whether the plan boundary is narrow enough: remove the current `gh aw` workflow line and its durable docs, without drifting into replacement design in the same execution PR.

## Links

- GitHub issue `#231`: https://github.com/yoskeoka/ww/issues/231

## Breaking Changes

N/A
