### PR TITLE
docs: move gh aw reintroduction tracking into docs/issues

### DIFF
--- a/docs/issues/done/gh-aw-custom-safe-output-not-emitted.md
+++ b/docs/issues/done/gh-aw-custom-safe-output-not-emitted.md
@@ -19,3 +19,7 @@ Investigate gh-aw/Copilot custom safe-output invocation semantics and update the
 ## Priority
 
 High for workflow correctness. The current PR removes stale formal reviews, but the intended durable comment upsert path depends on gh-aw detecting the custom output type and running the custom job.
+
+## Follow-up
+
+If CI-side agentic PR review is reconsidered in this repository, revisit this issue together with [docs/issues/gh-aw-reintroduction-needs-fresh-decision.md](../gh-aw-reintroduction-needs-fresh-decision.md).

--- a/docs/issues/done/plan-review-upsert-pr-comment-permission.md
+++ b/docs/issues/done/plan-review-upsert-pr-comment-permission.md
@@ -53,3 +53,7 @@ Concrete checks:
 Medium. This does not block the underlying code verification, but it causes a
 review workflow to fail for workflow-infrastructure reasons and should be fixed
 before relying on the durable PR-comment path.
+
+## Follow-up
+
+If CI-side agentic PR review is reconsidered in this repository, revisit this issue together with [docs/issues/gh-aw-reintroduction-needs-fresh-decision.md](../gh-aw-reintroduction-needs-fresh-decision.md).

--- a/docs/issues/gh-aw-reintroduction-needs-fresh-decision.md
+++ b/docs/issues/gh-aw-reintroduction-needs-fresh-decision.md
@@ -1,0 +1,47 @@
+# Reintroducing agentic PR review after `gh aw` removal needs a fresh decision
+
+**GitHub:** https://github.com/yoskeoka/ww/issues/231
+**Type:** docs | **Priority:** Medium
+
+## Problem
+
+The repository removed the `gh aw`-based PR review workflows because they no longer justified their operational cost, but the rationale and the restart conditions were recorded on GitHub issue `#231` instead of in `docs/issues/`.
+
+Without a local issue, the repository loses the intended durable record for:
+
+- why the current `gh aw` workflow line was removed
+- why removal was chosen over repairing the existing workflows immediately
+- what must be decided before any CI-side agentic PR review is reintroduced
+
+## Current Decision
+
+Keep the `gh aw` review workflows removed for now.
+
+Reasoning:
+
+- the recent runtime behavior no longer matched the intended review contract
+- the workflows created avoidable CI noise that was hard to distinguish from real regressions
+- the team has already adapted to reviewing PRs without these workflows
+- the billing/contract situation for running multiple CI-side agentic reviews is not a good fit right now
+
+## Reintroduction Blockers
+
+Do not reintroduce agentic PR review workflows until the repository makes an explicit decision on all of the following:
+
+- which backend agent runtime should be used in CI
+- whose contract or billing model will fund the CI usage
+- which API key or token model is compatible with the intended GitHub Actions execution pattern
+
+## Revisit Together If Reintroducing
+
+If the repository decides to reintroduce CI-side agentic review, revisit the older `gh aw` issue history at the same time instead of treating the removal as the only missing step.
+
+- [docs/issues/done/gh-aw-custom-safe-output-not-emitted.md](done/gh-aw-custom-safe-output-not-emitted.md)
+- [docs/issues/done/plan-review-upsert-pr-comment-permission.md](done/plan-review-upsert-pr-comment-permission.md)
+
+Those issues capture concrete runtime and permission failures in the removed workflow line. Any restart decision should either confirm they no longer apply under the new backend/credential model or replace them with an explicitly different design.
+
+## References
+
+- `docs/exec-plan/done/remove-gh-agentic-workflow.md`
+- GitHub issue `#231`


### PR DESCRIPTION
## Summary
- move the gh aw removal rationale and reintroduction blockers from GitHub issue #231 into docs/issues
- add explicit restart-time links from the two obsoleted gh aw done issues
- close the misfiled GitHub issue now that local docs/issues owns the durable tracking

## Verification
- make lint
- make test