### PR TITLE
Add ww create/cd parallel dogfooding report

### DIFF
--- a/docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md
+++ b/docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md
@@ -1,0 +1,29 @@
+# `ww create` and `ww cd` Can Fail When Started in Parallel for the Same Branch
+
+## Summary
+
+During workflow dogfooding from the workspace root, an AI agent started `ww create --repo ai-arena plan/dungeon-sidecar-boundary`
+and `ww cd --repo ai-arena plan/dungeon-sidecar-boundary` in parallel instead of waiting for `create` to finish first.
+
+- repo: `ai-arena`
+- triggering workspace: `vibe-coding-workspace`
+- cwd: workspace root `vibe-coding-workspace/`
+- commands started in parallel:
+  - `ww create --repo ai-arena plan/dungeon-sidecar-boundary`
+  - `ww cd --repo ai-arena plan/dungeon-sidecar-boundary`
+- actual:
+  - `ww create --repo ai-arena plan/dungeon-sidecar-boundary` succeeded and reported:
+    `/home/yoske/src/github.com/yoskeoka/vibe-coding-workspace/.worktrees/ai-arena@plan-dungeon-sidecar-boundary`
+  - `ww cd --repo ai-arena plan/dungeon-sidecar-boundary` failed with:
+    `no worktree found for branch "plan/dungeon-sidecar-boundary"`
+
+## Impact
+
+AI agents may try to optimize startup by parallelizing adjacent shell steps. When `ww create` and `ww cd` for the same
+branch are started concurrently, the `cd` side can observe a not-yet-created worktree and fail even though `create`
+eventually succeeds.
+
+## Notes
+
+- This report records only the observed commands and result.
+- It does not claim that `ww create` followed by `ww cd` fails when run sequentially.

--- a/docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md
+++ b/docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md
@@ -2,13 +2,14 @@
 
 ## Summary
 
-During workflow dogfooding from the workspace root, an AI agent started `ww create --repo ai-arena plan/dungeon-sidecar-boundary`
-and `ww cd --repo ai-arena plan/dungeon-sidecar-boundary` in parallel instead of waiting for `create` to finish first.
+During workflow dogfooding from the workspace root, an AI agent used `multi_tool_use.parallel` to start
+`ww create --repo ai-arena plan/dungeon-sidecar-boundary` and `ww cd --repo ai-arena plan/dungeon-sidecar-boundary`
+at the same time instead of waiting for `create` to finish first.
 
 - repo: `ai-arena`
 - triggering workspace: `vibe-coding-workspace`
 - cwd: workspace root `vibe-coding-workspace/`
-- commands started in parallel:
+- commands started in parallel via `multi_tool_use.parallel`:
   - `ww create --repo ai-arena plan/dungeon-sidecar-boundary`
   - `ww cd --repo ai-arena plan/dungeon-sidecar-boundary`
 - actual:


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `N/A`
- **Issues**: `docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md`

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `今回やってしまった内容をwwのdocs/issueに報告をしてPR作成してほしい。docs-onlyで検証などは不要です。また、解法を考える必要もなく、ただやったことと失敗した結果だけ添えて。`

### Additional Context from Instructing Human

The human explicitly asked not to propose a solution. This PR only records the observed commands and failure result from the agent's workflow use so the `ww` maintainers can decide whether and how to address it.

## Verification

- [ ] Tests pass (command: `N/A (docs-only by instruction)`)
- [ ] Lint passes (command: `N/A (docs-only by instruction)`)
- [x] Manual verification (describe below)

Manual verification:

- confirmed the new issue file is the only repo change
- confirmed the issue text only records the observed commands and failure result, without proposing a fix

## Deterministic Golden Updates

- [ ] This PR updates a deterministic regression golden
- Allowed update reason: `N/A`
- Spec/plan reference that records the same reason: `N/A`

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

This is a dogfooding report only. Please review whether the wording accurately captures the observed parallel `ww create` / `ww cd` usage and the resulting failure.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

N/A
