### PR TITLE
plan: add basic help improvements plan

### DIFF
--- a/docs/exec-plan/todo/0026-help-improvements-basic-worktree-flows.md
+++ b/docs/exec-plan/todo/0026-help-improvements-basic-worktree-flows.md
@@ -8,8 +8,8 @@ command help, without requiring a separately distributed workflow skill.
 
 This plan improves `ww --help`, `ww create --help`, and `ww cd --help` so the
 basic worktree lifecycle and the recommended create-vs-cd flows are visible at
-the CLI entry point, including the explicit create-and-enter path via
-`ww create -q`.
+the CLI entry point, including the explicit create-and-enter shell pattern
+`cd "$(ww create -q ...)"`.
 
 ## Context
 
@@ -27,10 +27,11 @@ the CLI entry point, including the explicit create-and-enter path via
     and `ww clean`
   - concrete examples for create-and-enter, open-existing, and workspace-root
     `--repo` usage
-- `ww create --help` explains that `ww create -q` is the preferred
-  create-and-enter path
+- `ww create --help` explains that `ww create -q` is the preferred path-only
+  command for the create-and-enter shell pattern
 - `ww cd --help` explains that `ww cd` is for opening an existing worktree and
-  points create-and-enter users back to `ww create -q`
+  points create-and-enter users back to the
+  `cd "$(ww create -q ...)"` pattern
 - README/spec text stays aligned with the CLI help contract
 
 ## Scope
@@ -42,7 +43,7 @@ the CLI entry point, including the explicit create-and-enter path via
 - Add durable examples and flow wording to docs/specs where needed so the help
   text is not a one-off undocumented behavior.
 - Clarify the user-facing role split:
-  - create and enter immediately: `ww create -q`
+  - create and enter immediately: `cd "$(ww create -q ...)"`
   - open an existing worktree: `ww cd`
 
 ## Out of Scope
@@ -62,9 +63,10 @@ the CLI entry point, including the explicit create-and-enter path via
     - `ww cd feat/my-feature`
     - `ww create --repo backend feat/my-feature`
 - Update `cmd/ww/sub_create.go` help output to explain immediate-entry usage and
-  point users to `ww create -q`.
+  point users to `cd "$(ww create -q ...)"`.
 - Update `cmd/ww/sub_cd.go` help output to explain that `ww cd` opens an
-  existing worktree and to redirect create-and-enter flows to `ww create -q`.
+  existing worktree and to redirect create-and-enter flows to
+  `cd "$(ww create -q ...)"`.
 - Introduce shared help-formatting helpers only if doing so keeps command help
   consistent without making the CLI wiring harder to read.
 
@@ -72,7 +74,8 @@ the CLI entry point, including the explicit create-and-enter path via
 
 - Update `docs/specs/cli-commands.md` so the help-facing guidance is durable:
   - top-level help includes a basic workflow example set
-  - `ww create` help highlights `-q` for create-and-enter
+  - `ww create` help highlights `-q` as the path-only part of the
+    create-and-enter shell pattern
   - `ww cd` help highlights its existing-worktree role
 - Update `docs/specs/shell-integration.md` if needed so the same create-vs-cd
   role split is stated consistently outside the CLI help output.
@@ -87,6 +90,8 @@ the CLI entry point, including the explicit create-and-enter path via
   with real variations such as starting from `ww create -q` directly.
 - Reuse the same wording for create/cd role separation across help, specs, and
   README to avoid drift.
+- Keep the shell contract explicit: `ww create -q` prints a path; the shell's
+  surrounding `cd "$( ... )"` performs navigation.
 
 ## Sub-tasks
 

--- a/docs/exec-plan/todo/0026-help-improvements-basic-worktree-flows.md
+++ b/docs/exec-plan/todo/0026-help-improvements-basic-worktree-flows.md
@@ -1,0 +1,125 @@
+# 0026: Help Improvements for Basic Worktree Flows
+**Execution**: Use `/execute-task` to implement this plan.
+
+## Objective
+
+Make `ww` self-explanatory for first-time users and agents that only consult
+command help, without requiring a separately distributed workflow skill.
+
+This plan improves `ww --help`, `ww create --help`, and `ww cd --help` so the
+basic worktree lifecycle and the recommended create-vs-cd flows are visible at
+the CLI entry point, including the explicit create-and-enter path via
+`ww create -q`.
+
+## Context
+
+- The current top-level help in `cmd/ww/main.go` lists commands and flags but
+  does not show a basic usage flow or recommended examples.
+- The user wants `ww` to explain itself even when it has not yet been embedded
+  in a larger workflow package.
+- `docs/project-plan.md` positions `ww` as agent-friendly and human-usable,
+  so the built-in help should teach the common path directly.
+
+## Expected Outcome
+
+- `ww --help` shows:
+  - a compact lifecycle-oriented flow using `ww list`, `ww create`, `ww cd`,
+    and `ww clean`
+  - concrete examples for create-and-enter, open-existing, and workspace-root
+    `--repo` usage
+- `ww create --help` explains that `ww create -q` is the preferred
+  create-and-enter path
+- `ww cd --help` explains that `ww cd` is for opening an existing worktree and
+  points create-and-enter users back to `ww create -q`
+- README/spec text stays aligned with the CLI help contract
+
+## Scope
+
+- Improve built-in help output for:
+  - `ww --help`
+  - `ww create --help`
+  - `ww cd --help`
+- Add durable examples and flow wording to docs/specs where needed so the help
+  text is not a one-off undocumented behavior.
+- Clarify the user-facing role split:
+  - create and enter immediately: `ww create -q`
+  - open an existing worktree: `ww cd`
+
+## Out of Scope
+
+- New subcommands or aliases
+- Full tutorial output or interactive onboarding wizard
+- Skill packaging and distribution
+- Changing the core command semantics beyond what is needed to support clearer
+  help text
+
+## Code Changes
+
+- Update `cmd/ww/main.go` top-level usage output to include:
+  - a short "basic flow" section covering `list -> create -> cd -> clean`
+  - concrete examples for:
+    - `cd "$(ww create -q feat/my-feature)"`
+    - `ww cd feat/my-feature`
+    - `ww create --repo backend feat/my-feature`
+- Update `cmd/ww/sub_create.go` help output to explain immediate-entry usage and
+  point users to `ww create -q`.
+- Update `cmd/ww/sub_cd.go` help output to explain that `ww cd` opens an
+  existing worktree and to redirect create-and-enter flows to `ww create -q`.
+- Introduce shared help-formatting helpers only if doing so keeps command help
+  consistent without making the CLI wiring harder to read.
+
+## Spec Changes
+
+- Update `docs/specs/cli-commands.md` so the help-facing guidance is durable:
+  - top-level help includes a basic workflow example set
+  - `ww create` help highlights `-q` for create-and-enter
+  - `ww cd` help highlights its existing-worktree role
+- Update `docs/specs/shell-integration.md` if needed so the same create-vs-cd
+  role split is stated consistently outside the CLI help output.
+- Update `README.md` if needed so the examples shown there match the new
+  top-level help wording and ordering.
+
+## Design Notes
+
+- Keep top-level help compact. It should teach the default mental model quickly,
+  not become a full manual.
+- The flow section should be descriptive, not normative in a way that conflicts
+  with real variations such as starting from `ww create -q` directly.
+- Reuse the same wording for create/cd role separation across help, specs, and
+  README to avoid drift.
+
+## Sub-tasks
+
+- [ ] Define the exact top-level help structure: usage, command list, basic
+  flow, examples, then global flags
+- [ ] [parallel] Update `docs/specs/cli-commands.md` with the intended help
+  guidance contract
+- [ ] [parallel] Update `README.md` examples/order if the durable docs need to
+  mirror the new top-level flow
+- [ ] [depends on: help structure] Implement top-level help improvements in
+  `cmd/ww/main.go`
+- [ ] [depends on: help structure] Implement targeted guidance in
+  `cmd/ww/sub_create.go` and `cmd/ww/sub_cd.go`
+- [ ] [depends on: implementation] Add or update CLI help tests if the current
+  suite already covers help output; otherwise add focused coverage for the new
+  sections
+
+## Verification
+
+- `go test ./...`
+- Manual output checks:
+  - `ww --help`
+  - `ww create --help`
+  - `ww cd --help`
+- Confirm the examples and flow wording still make sense for:
+  - single-repo usage
+  - workspace-root usage with `--repo`
+
+## Risks
+
+- Overly verbose help text would reduce scanability and hide the important
+  examples.
+- If top-level and subcommand help diverge, users will see conflicting guidance.
+- Help text that over-prescribes one shell pattern could confuse users on shells
+  where command substitution syntax differs; examples should stay explicit about
+  what is being illustrated.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/todo/0026-help-improvements-basic-worktree-flows.md`
- **Issues**: N/A

## Closes

N/A

## Type of Change

- [ ] Project Plan update
- [x] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `$plan-execution ww/docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md`
### Additional Context from Instructing Human

The human accepted two separate planning PRs. This PR is intentionally scoped to built-in help and guidance: `ww --help` should show the general `ww list -> ww create -> ww cd -> ww clean` flow, include concrete examples, and make `ww create -q` the explicit create-and-enter path. The bounded `ww cd` retry planning work is tracked separately.

## Verification

- [ ] Tests pass (command: `N/A - docs-only planning PR`)
- [ ] Lint passes (command: `N/A - docs-only planning PR`)
- [x] Manual verification (describe below)

Confirmed the PR contains only the new execution plan file for top-level and subcommand help improvements, with no implementation or unrelated docs changes.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo` to `done` — _if executing a plan_
- [ ] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [ ] External GitHub issues declared in the plan's `Addresses:` line are linked under `Issues`, and implementation PRs include matching `Closes` entries or explain why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

Review focus: whether the plan keeps the help work self-contained and clearly documents the intended top-level flow and create-vs-cd guidance without mixing in the separate retry implementation plan.

Workflow-linter note: pre-push is expected to report one existing fixable warning for active issue file `docs/issues/ww-create-and-cd-run-in-parallel-can-fail.md` not yet using the numbered filename convention. This PR intentionally leaves that pre-existing issue path unchanged because the human-directed scope here is only to add the help-focused execution plan.

## Links

N/A

## Breaking Changes

N/A
