### PR TITLE
chore: filter Japanese markdown in slopless CI

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -50,12 +50,38 @@ jobs:
             exit 1
           fi
 
+          contains_japanese_text() {
+            local path="$1"
+            python3 - "$path" <<'PY'
+          import sys
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          content = path.read_text(encoding="utf-8", errors="ignore")
+          for char in content:
+              codepoint = ord(char)
+              if (
+                  0x3040 <= codepoint <= 0x30FF
+                  or 0x31F0 <= codepoint <= 0x31FF
+                  or 0x3400 <= codepoint <= 0x4DBF
+                  or 0x4E00 <= codepoint <= 0x9FFF
+                  or 0xF900 <= codepoint <= 0xFAFF
+                  or 0xFF65 <= codepoint <= 0xFF9F
+              ):
+                  raise SystemExit(0)
+          raise SystemExit(1)
+          PY
+          }
+
           mapfile -t files < <(
             git diff --name-only --diff-filter=AMR "${BASE_REF}...HEAD" | while IFS= read -r path; do
               [ -n "$path" ] || continue
               [ -f "$path" ] || continue
               case "$path" in
-                *.md) printf '%s\n' "$path" ;;
+                *.md)
+                  contains_japanese_text "$path" && continue
+                  printf '%s\n' "$path"
+                  ;;
               esac
             done
           )


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `vibe-coding-workspace/docs/exec-plan/done/0041-child-repo-slopless-japanese-filter-sync.md`
- **Issues**: N/A

## Closes

N/A

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [x] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `$execute-task docs/exec-plan/todo/0041-child-repo-slopless-japanese-filter-sync.md 実行して`

### Additional Context from Instructing Human

- Keep fixes limited to `.github/workflows/slopless.yml`.
- Preserve the repository's existing Markdown path scope.
- Do not remediate existing `slopless` findings in this rollout.

## Verification

- [ ] Tests pass (command: `N/A`)
- [x] Lint passes (command: `pinact run .github/workflows/slopless.yml && python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/slopless.yml"))' && git diff --check && tools/workflow-lint.sh --mode=ci --pr-title='chore: filter Japanese markdown in slopless CI' --pr-body='<this PR body>'`)
- [x] Manual verification (describe below)

Manual verification:
- Confirmed the diff is limited to `.github/workflows/slopless.yml`.
- Confirmed the inline changed-Markdown detector now skips files containing Japanese-writing characters while preserving the repo's existing path scope.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo` to `done` — _if executing a plan_
- [ ] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [ ] External GitHub issues declared in the plan's `Addresses:` line are linked under `Issues`, and implementation PRs include matching `Closes` entries or explain why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- This PR only ports the workspace's Japanese-text exclusion into the repo-local inline detector.
- Existing path scope is preserved intentionally.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

- `pinact run .github/workflows/slopless.yml`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/slopless.yml"))'`
- `git diff --check`
