### PR TITLE
plan: add ww Phase 5 global config child plans

### DIFF
--- a/docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md
+++ b/docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md
@@ -1,37 +1,36 @@
-# 0028: Phase 5 global config base
+# 0028: Phase 5 Global Config Foundation
 
-> **Execution**
-> Run `/execute-task` for this plan.
+> **Execution**: Use `/execute-task` to implement this plan.
 
 ## Objective
 
-Set the base rules for Phase 5 global config in `ww`. Cover the user config path, repo-local vs global precedence, full override per key, and sandbox guidance.
+Establish the Phase 5 global-config foundation for `ww`: a user-owned config location, deterministic precedence between repo-local and global config, full-override merge semantics, and sandbox-safe guidance for loading global settings without requiring every repository to commit `.ww.toml`.
 
 ## Context
 
-- `docs/project-plan.md` defines Phase 5 as FR-27 through FR-30.
-- `docs/specs/configuration.md` and `internal/config/config.go` now load one repo-local `.ww.toml`.
-- `post_create_hook` already runs as trusted shell input.
+- `docs/project-plan.md` defines Phase 5 as global config and hook workflow portability, specifically FR-27 through FR-30.
+- `docs/specs/configuration.md` and `internal/config/config.go` currently model configuration as a single repo-local `.ww.toml` discovered from the current directory upward, with a few explicit fallback directories.
+- Existing config is intentionally simple and trusted, and `post_create_hook` already executes as trusted shell input. Phase 5 should extend that model cautiously rather than introducing implicit config composition that is hard to reason about.
 - Human direction for this plan:
   - Global config default path is `$HOME/.config/ww/config.toml`.
   - If `XDG_CONFIG_HOME` is set, use `$XDG_CONFIG_HOME/ww/config.toml` instead.
   - Repo-local config found via existing search rules has higher priority than global config.
   - Matching keys override completely rather than merging deeply or appending.
-  - Hook values replace the whole lower layer.
+  - Hook values must be replaced as a whole, not partially composed.
 
 ## Options and Trade-offs
 
-1. **Use global config as defaults and repo-local config as full override (recommended)**
+1. **Global config as defaults, repo-local config as full override (recommended)**
    - Pros: Simple mental model. Keeps existing repo-local behavior authoritative. Avoids surprising hook composition and duplicate `copy_files` / `symlink_files` outcomes.
-   - Cons: Users must repeat full arrays or hook strings.
-2. **Merge some fields and append some arrays**
+   - Cons: Users must repeat full arrays or hook strings when overriding only one element.
+2. **Per-field merge with array append for selected keys**
    - Pros: Less repetition for additive lists.
-   - Cons: Harder to explain and test. It also changes hook and file setup behavior in less obvious ways.
-3. **Use global config only when no repo-local config exists**
+   - Cons: Harder to explain and test. Implicitly changes hook/materialization behavior when global and local config interact. Duplicate entries, ordering, and partial override rules become policy decisions instead of straightforward precedence.
+3. **Global config only when no repo-local config exists**
    - Pros: Minimal implementation.
-   - Cons: Too weak for the portability goal.
+   - Cons: Too weak for the stated portability goal because repo-local config cannot override a shared user baseline selectively.
 
-**Recommended option** Put global config on the lower layer. Let repo-local config replace each matching key.
+**Recommendation**: Option 1. Treat global config as a lower-priority default layer and repo-local config as a full replacement per key. Defer any additive semantics to a future explicit opt-in design if real usage proves the need.
 **Decision (2026-06-01)**: Human confirmed XDG-aware global config discovery plus repo-local-wins precedence with complete override semantics for all keys, including arrays and hooks.
 
 ## Scope
@@ -48,31 +47,31 @@ Set the base rules for Phase 5 global config in `ww`. Cover the user config path
 
 - Project-target matching rules beyond the foundation hooks needed by Phase 5-02
 - Reusable profile syntax beyond the loader/model support needed by Phase 5-03
-- Hook trust hardening such as confirmations or dangerous-pattern scanning. That belongs to Phase 7.
+- Hook trust hardening such as confirmations or dangerous-pattern scanning; that belongs to Phase 7
 
 ## Spec Changes
 
 | File | Change |
 |------|--------|
-| `docs/specs/configuration.md` | Add global config path rules, XDG behavior, precedence, and full-override rules |
-| `docs/specs/cli-commands.md` | Note any visible effect of global config loading on create/list/remove |
-| `docs/specs/workspace-discovery.md` | Clarify sandbox-boundary behavior if needed |
+| `docs/specs/configuration.md` | Add global config path rules, XDG behavior, precedence order, and full-override merge semantics |
+| `docs/specs/cli-commands.md` | Document any CLI-visible consequences of global config loading, especially when config source affects create/list/remove behavior |
+| `docs/specs/workspace-discovery.md` | Clarify any sandbox-boundary interaction with global config lookup if the execution design needs it |
 | `docs/project-plan.md` | Mark FR-27 and FR-30 status updates only if this child plan completes those requirements fully |
 
 ## Design Decision Changes
 
 | File | Change |
 |------|--------|
-| `docs/design-decisions/adr.md` | Add an ADR for the global config path, precedence, and full-override model |
+| `docs/design-decisions/adr.md` | Append ADR for the global config location, precedence order, and complete-override layering model |
 
 ## Code Changes
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Add global config loading, layering, and precedence |
-| `internal/config/config_test.go` | Add unit tests for XDG path selection, `$HOME/.config/ww`, and override rules |
-| `cmd/ww/main.go` | Pass the layered config result into manager setup |
-| `worktree/worktree.go` | Accept any needed config model additions |
+| `internal/config/config.go` | Extend config loading to support a global config source, layering, and source-aware precedence |
+| `internal/config/config_test.go` | Add unit coverage for XDG path selection, fallback to `$HOME/.config/ww`, and override semantics |
+| `cmd/ww/main.go` | Thread the layered config result into manager construction without changing existing command contracts |
+| `worktree/worktree.go` | Accept any required config model additions while preserving current behavior for existing repo-local configs |
 
 ## Test Changes
 
@@ -87,8 +86,8 @@ Set the base rules for Phase 5 global config in `ww`. Cover the user config path
 
 ## Design Notes
 
-- The precedence rule should stay explicit and uniform. The higher-priority config replaces the lower-priority value for the same key.
-- Skip implicit append behavior in Phase 5.
+- The precedence rule should be explicit and uniform: the higher-priority config replaces the lower-priority value for the same key, regardless of value type.
+- Do not introduce implicit append behavior in Phase 5. If additive reuse becomes necessary later, design it as explicit syntax instead of hidden merge magic.
 - Global config should remain optional. Existing repositories that rely only on `.ww.toml` must continue to work unchanged.
 - Sandbox guidance should prefer readable global config and avoid recommending writable global config paths to agent sandboxes.
 
@@ -96,10 +95,10 @@ Set the base rules for Phase 5 global config in `ww`. Cover the user config path
 
 - [ ] [parallel] Update `docs/specs/configuration.md` with global path, XDG behavior, precedence order, and complete-override semantics
 - [ ] [parallel] Append ADR for global config layering and trust boundary
-- [ ] [depends on: specs, ADR] Add global config discovery and deterministic layering in `internal/config`
+- [ ] [depends on: specs, ADR] Implement global config discovery and deterministic layering in `internal/config`
 - [ ] [depends on: implementation] Thread the layered config result through manager setup without breaking current behavior
 - [ ] [depends on: implementation] Add loader and command regression tests for XDG/global/repo-local precedence
-- [ ] [depends on: verification] Decide whether FR-27 and FR-30 are done now or stay partial until later Phase 5 child plans land
+- [ ] [depends on: verification] Decide whether FR-27 and FR-30 can be marked implemented immediately or remain partial until later Phase 5 child plans land
 
 ## Verification
 
@@ -107,6 +106,6 @@ Set the base rules for Phase 5 global config in `ww`. Cover the user config path
 - Manual verification:
   - with only global config present, `ww` picks it up
   - with both global and repo-local config present, repo-local values win per key
-  - array and hook fields replace the lower layer as a whole
+  - array and hook fields are replaced completely, not appended or composed
   - when `XDG_CONFIG_HOME` is set, `ww` prefers `$XDG_CONFIG_HOME/ww/config.toml`
   - when `XDG_CONFIG_HOME` is unset, `ww` falls back to `$HOME/.config/ww/config.toml`

--- a/docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md
+++ b/docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md
@@ -1,0 +1,111 @@
+# 0028: Phase 5 Global Config Foundation
+
+> **Execution**: Use `/execute-task` to implement this plan.
+
+## Objective
+
+Establish the Phase 5 global-config foundation for `ww`: a user-owned config location, deterministic precedence between repo-local and global config, full-override merge semantics, and sandbox-safe guidance for loading global settings without requiring every repository to commit `.ww.toml`.
+
+## Context
+
+- `docs/project-plan.md` defines Phase 5 as global config and hook workflow portability, specifically FR-27 through FR-30.
+- `docs/specs/configuration.md` and `internal/config/config.go` currently model configuration as a single repo-local `.ww.toml` discovered from the current directory upward, with a few explicit fallback directories.
+- Existing config is intentionally simple and trusted, and `post_create_hook` already executes as trusted shell input. Phase 5 should extend that model cautiously rather than introducing implicit config composition that is hard to reason about.
+- Human direction for this plan:
+  - Global config default path is `$HOME/.config/ww/config.toml`.
+  - If `XDG_CONFIG_HOME` is set, use `$XDG_CONFIG_HOME/ww/config.toml` instead.
+  - Repo-local config found via existing search rules has higher priority than global config.
+  - Matching keys override completely rather than merging deeply or appending.
+  - Hook values must be replaced as a whole, not partially composed.
+
+## Options and Trade-offs
+
+1. **Global config as defaults, repo-local config as full override (recommended)**
+   - Pros: Simple mental model. Keeps existing repo-local behavior authoritative. Avoids surprising hook composition and duplicate `copy_files` / `symlink_files` outcomes.
+   - Cons: Users must repeat full arrays or hook strings when overriding only one element.
+2. **Per-field merge with array append for selected keys**
+   - Pros: Less repetition for additive lists.
+   - Cons: Harder to explain and test. Implicitly changes hook/materialization behavior when global and local config interact. Duplicate entries, ordering, and partial override rules become policy decisions instead of straightforward precedence.
+3. **Global config only when no repo-local config exists**
+   - Pros: Minimal implementation.
+   - Cons: Too weak for the stated portability goal because repo-local config cannot override a shared user baseline selectively.
+
+**Recommendation**: Option 1. Treat global config as a lower-priority default layer and repo-local config as a full replacement per key. Defer any additive semantics to a future explicit opt-in design if real usage proves the need.
+**Decision (2026-06-01)**: Human confirmed XDG-aware global config discovery plus repo-local-wins precedence with complete override semantics for all keys, including arrays and hooks.
+
+## Scope
+
+### In Scope
+
+- Define the global config search path and precedence order
+- Specify the layer model between global config and repo-local config
+- Define full-override merge semantics for scalar, array, and hook fields
+- Document safe sandbox guidance for read-only global config usage
+- Introduce the code seams needed for later Phase 5 child plans
+
+### Out of Scope
+
+- Project-target matching rules beyond the foundation hooks needed by Phase 5-02
+- Reusable profile syntax beyond the loader/model support needed by Phase 5-03
+- Hook trust hardening such as confirmations or dangerous-pattern scanning; that belongs to Phase 7
+
+## Spec Changes
+
+| File | Change |
+|------|--------|
+| `docs/specs/configuration.md` | Add global config path rules, XDG behavior, precedence order, and full-override merge semantics |
+| `docs/specs/cli-commands.md` | Document any CLI-visible consequences of global config loading, especially when config source affects create/list/remove behavior |
+| `docs/specs/workspace-discovery.md` | Clarify any sandbox-boundary interaction with global config lookup if the execution design needs it |
+| `docs/project-plan.md` | Mark FR-27 and FR-30 status updates only if this child plan completes those requirements fully |
+
+## Design Decision Changes
+
+| File | Change |
+|------|--------|
+| `docs/design-decisions/adr.md` | Append ADR for the global config location, precedence order, and complete-override layering model |
+
+## Code Changes
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Extend config loading to support a global config source, layering, and source-aware precedence |
+| `internal/config/config_test.go` | Add unit coverage for XDG path selection, fallback to `$HOME/.config/ww`, and override semantics |
+| `cmd/ww/main.go` | Thread the layered config result into manager construction without changing existing command contracts |
+| `worktree/worktree.go` | Accept any required config model additions while preserving current behavior for existing repo-local configs |
+
+## Test Changes
+
+- Add loader tests covering:
+  - `XDG_CONFIG_HOME` set
+  - `XDG_CONFIG_HOME` unset with `$HOME/.config/ww/config.toml`
+  - no global config present
+  - repo-local config overriding scalar fields
+  - repo-local config overriding array fields without append
+  - repo-local config overriding hook fields without composition
+- Add command-level regression coverage proving current repo-local-only behavior remains unchanged when no global config file exists.
+
+## Design Notes
+
+- The precedence rule should be explicit and uniform: the higher-priority config replaces the lower-priority value for the same key, regardless of value type.
+- Do not introduce implicit append behavior in Phase 5. If additive reuse becomes necessary later, design it as explicit syntax instead of hidden merge magic.
+- Global config should remain optional. Existing repositories that rely only on `.ww.toml` must continue to work unchanged.
+- Sandbox guidance should prefer readable global config and avoid recommending writable global config paths to agent sandboxes.
+
+## Sub-tasks
+
+- [ ] [parallel] Update `docs/specs/configuration.md` with global path, XDG behavior, precedence order, and complete-override semantics
+- [ ] [parallel] Append ADR for global config layering and trust boundary
+- [ ] [depends on: specs, ADR] Implement global config discovery and deterministic layering in `internal/config`
+- [ ] [depends on: implementation] Thread the layered config result through manager setup without breaking current behavior
+- [ ] [depends on: implementation] Add loader and command regression tests for XDG/global/repo-local precedence
+- [ ] [depends on: verification] Decide whether FR-27 and FR-30 can be marked implemented immediately or remain partial until later Phase 5 child plans land
+
+## Verification
+
+- `go test ./internal/config ./cmd/ww ./worktree`
+- Manual verification:
+  - with only global config present, `ww` picks it up
+  - with both global and repo-local config present, repo-local values win per key
+  - array and hook fields are replaced completely, not appended or composed
+  - when `XDG_CONFIG_HOME` is set, `ww` prefers `$XDG_CONFIG_HOME/ww/config.toml`
+  - when `XDG_CONFIG_HOME` is unset, `ww` falls back to `$HOME/.config/ww/config.toml`

--- a/docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md
+++ b/docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md
@@ -1,36 +1,37 @@
-# 0028: Phase 5 Global Config Foundation
+# 0028: Phase 5 global config base
 
-> **Execution**: Use `/execute-task` to implement this plan.
+> **Execution**
+> Run `/execute-task` for this plan.
 
 ## Objective
 
-Establish the Phase 5 global-config foundation for `ww`: a user-owned config location, deterministic precedence between repo-local and global config, full-override merge semantics, and sandbox-safe guidance for loading global settings without requiring every repository to commit `.ww.toml`.
+Set the base rules for Phase 5 global config in `ww`. Cover the user config path, repo-local vs global precedence, full override per key, and sandbox guidance.
 
 ## Context
 
-- `docs/project-plan.md` defines Phase 5 as global config and hook workflow portability, specifically FR-27 through FR-30.
-- `docs/specs/configuration.md` and `internal/config/config.go` currently model configuration as a single repo-local `.ww.toml` discovered from the current directory upward, with a few explicit fallback directories.
-- Existing config is intentionally simple and trusted, and `post_create_hook` already executes as trusted shell input. Phase 5 should extend that model cautiously rather than introducing implicit config composition that is hard to reason about.
+- `docs/project-plan.md` defines Phase 5 as FR-27 through FR-30.
+- `docs/specs/configuration.md` and `internal/config/config.go` now load one repo-local `.ww.toml`.
+- `post_create_hook` already runs as trusted shell input.
 - Human direction for this plan:
   - Global config default path is `$HOME/.config/ww/config.toml`.
   - If `XDG_CONFIG_HOME` is set, use `$XDG_CONFIG_HOME/ww/config.toml` instead.
   - Repo-local config found via existing search rules has higher priority than global config.
   - Matching keys override completely rather than merging deeply or appending.
-  - Hook values must be replaced as a whole, not partially composed.
+  - Hook values replace the whole lower layer.
 
 ## Options and Trade-offs
 
-1. **Global config as defaults, repo-local config as full override (recommended)**
+1. **Use global config as defaults and repo-local config as full override (recommended)**
    - Pros: Simple mental model. Keeps existing repo-local behavior authoritative. Avoids surprising hook composition and duplicate `copy_files` / `symlink_files` outcomes.
-   - Cons: Users must repeat full arrays or hook strings when overriding only one element.
-2. **Per-field merge with array append for selected keys**
+   - Cons: Users must repeat full arrays or hook strings.
+2. **Merge some fields and append some arrays**
    - Pros: Less repetition for additive lists.
-   - Cons: Harder to explain and test. Implicitly changes hook/materialization behavior when global and local config interact. Duplicate entries, ordering, and partial override rules become policy decisions instead of straightforward precedence.
-3. **Global config only when no repo-local config exists**
+   - Cons: Harder to explain and test. It also changes hook and file setup behavior in less obvious ways.
+3. **Use global config only when no repo-local config exists**
    - Pros: Minimal implementation.
-   - Cons: Too weak for the stated portability goal because repo-local config cannot override a shared user baseline selectively.
+   - Cons: Too weak for the portability goal.
 
-**Recommendation**: Option 1. Treat global config as a lower-priority default layer and repo-local config as a full replacement per key. Defer any additive semantics to a future explicit opt-in design if real usage proves the need.
+**Recommended option** Put global config on the lower layer. Let repo-local config replace each matching key.
 **Decision (2026-06-01)**: Human confirmed XDG-aware global config discovery plus repo-local-wins precedence with complete override semantics for all keys, including arrays and hooks.
 
 ## Scope
@@ -47,31 +48,31 @@ Establish the Phase 5 global-config foundation for `ww`: a user-owned config loc
 
 - Project-target matching rules beyond the foundation hooks needed by Phase 5-02
 - Reusable profile syntax beyond the loader/model support needed by Phase 5-03
-- Hook trust hardening such as confirmations or dangerous-pattern scanning; that belongs to Phase 7
+- Hook trust hardening such as confirmations or dangerous-pattern scanning. That belongs to Phase 7.
 
 ## Spec Changes
 
 | File | Change |
 |------|--------|
-| `docs/specs/configuration.md` | Add global config path rules, XDG behavior, precedence order, and full-override merge semantics |
-| `docs/specs/cli-commands.md` | Document any CLI-visible consequences of global config loading, especially when config source affects create/list/remove behavior |
-| `docs/specs/workspace-discovery.md` | Clarify any sandbox-boundary interaction with global config lookup if the execution design needs it |
+| `docs/specs/configuration.md` | Add global config path rules, XDG behavior, precedence, and full-override rules |
+| `docs/specs/cli-commands.md` | Note any visible effect of global config loading on create/list/remove |
+| `docs/specs/workspace-discovery.md` | Clarify sandbox-boundary behavior if needed |
 | `docs/project-plan.md` | Mark FR-27 and FR-30 status updates only if this child plan completes those requirements fully |
 
 ## Design Decision Changes
 
 | File | Change |
 |------|--------|
-| `docs/design-decisions/adr.md` | Append ADR for the global config location, precedence order, and complete-override layering model |
+| `docs/design-decisions/adr.md` | Add an ADR for the global config path, precedence, and full-override model |
 
 ## Code Changes
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Extend config loading to support a global config source, layering, and source-aware precedence |
-| `internal/config/config_test.go` | Add unit coverage for XDG path selection, fallback to `$HOME/.config/ww`, and override semantics |
-| `cmd/ww/main.go` | Thread the layered config result into manager construction without changing existing command contracts |
-| `worktree/worktree.go` | Accept any required config model additions while preserving current behavior for existing repo-local configs |
+| `internal/config/config.go` | Add global config loading, layering, and precedence |
+| `internal/config/config_test.go` | Add unit tests for XDG path selection, `$HOME/.config/ww`, and override rules |
+| `cmd/ww/main.go` | Pass the layered config result into manager setup |
+| `worktree/worktree.go` | Accept any needed config model additions |
 
 ## Test Changes
 
@@ -86,8 +87,8 @@ Establish the Phase 5 global-config foundation for `ww`: a user-owned config loc
 
 ## Design Notes
 
-- The precedence rule should be explicit and uniform: the higher-priority config replaces the lower-priority value for the same key, regardless of value type.
-- Do not introduce implicit append behavior in Phase 5. If additive reuse becomes necessary later, design it as explicit syntax instead of hidden merge magic.
+- The precedence rule should stay explicit and uniform. The higher-priority config replaces the lower-priority value for the same key.
+- Skip implicit append behavior in Phase 5.
 - Global config should remain optional. Existing repositories that rely only on `.ww.toml` must continue to work unchanged.
 - Sandbox guidance should prefer readable global config and avoid recommending writable global config paths to agent sandboxes.
 
@@ -95,10 +96,10 @@ Establish the Phase 5 global-config foundation for `ww`: a user-owned config loc
 
 - [ ] [parallel] Update `docs/specs/configuration.md` with global path, XDG behavior, precedence order, and complete-override semantics
 - [ ] [parallel] Append ADR for global config layering and trust boundary
-- [ ] [depends on: specs, ADR] Implement global config discovery and deterministic layering in `internal/config`
+- [ ] [depends on: specs, ADR] Add global config discovery and deterministic layering in `internal/config`
 - [ ] [depends on: implementation] Thread the layered config result through manager setup without breaking current behavior
 - [ ] [depends on: implementation] Add loader and command regression tests for XDG/global/repo-local precedence
-- [ ] [depends on: verification] Decide whether FR-27 and FR-30 can be marked implemented immediately or remain partial until later Phase 5 child plans land
+- [ ] [depends on: verification] Decide whether FR-27 and FR-30 are done now or stay partial until later Phase 5 child plans land
 
 ## Verification
 
@@ -106,6 +107,6 @@ Establish the Phase 5 global-config foundation for `ww`: a user-owned config loc
 - Manual verification:
   - with only global config present, `ww` picks it up
   - with both global and repo-local config present, repo-local values win per key
-  - array and hook fields are replaced completely, not appended or composed
+  - array and hook fields replace the lower layer as a whole
   - when `XDG_CONFIG_HOME` is set, `ww` prefers `$XDG_CONFIG_HOME/ww/config.toml`
   - when `XDG_CONFIG_HOME` is unset, `ww` falls back to `$HOME/.config/ww/config.toml`

--- a/docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md
+++ b/docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md
@@ -1,0 +1,96 @@
+# 0029: Phase 5 Global Config Project Target Matching
+
+> **Execution**: Use `/execute-task` to implement this plan.
+
+**Parent plan series**: `0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
+
+## Objective
+
+Add deterministic project-target matching on top of the Phase 5 global-config foundation so one user-owned config can apply different settings to different repositories or workspace members without relying on committed repo-local `.ww.toml` files.
+
+## Context
+
+- `docs/project-plan.md` defines FR-28 as global project-target matching using the main worktree as the stable target anchor.
+- The current config model is repository-scoped only. Once global config exists, `ww` needs a predictable way to select project-specific settings before the worktree manager runs.
+- Matching should stay simple enough for humans and agents to audit. Hidden fallback behavior or ambiguous best-match logic would conflict with the current repo-local simplicity.
+
+## Options and Trade-offs
+
+1. **Ordered project blocks with first-match-wins against the main worktree root (recommended)**
+   - Pros: Deterministic and easy to read. Supports intentional override ordering without inventing specificity scoring rules.
+   - Cons: Large configs may require careful ordering by the user.
+2. **Automatic most-specific-match-wins**
+   - Pros: Can reduce ordering burden in some cases.
+   - Cons: Specificity rules become another policy surface. Harder to explain when two patterns partially overlap.
+3. **Single exact-path match only**
+   - Pros: Very simple.
+   - Cons: Too rigid for the portability goal. Fails the use case of sharing settings across multiple similar repositories.
+
+**Recommendation**: Option 1. Match global project blocks in declared order against the main worktree root and stop at the first match. Keep the initial matcher narrow and explicit; add more sophisticated selection only if real usage demands it.
+
+## Scope
+
+### In Scope
+
+- Define the project-target matching syntax and evaluation order
+- Anchor matching on the repository main worktree root rather than the current secondary worktree path
+- Document failure/ignore behavior for invalid or unmatched target blocks
+- Add tests for overlapping rules and deterministic selection
+
+### Out of Scope
+
+- Materialization profile syntax itself; that belongs to Phase 5-03
+- Implicit combination of multiple matching project blocks
+- Recursive workspace policy engines or organization-wide config inheritance
+
+## Spec Changes
+
+| File | Change |
+|------|--------|
+| `docs/specs/configuration.md` | Add the global project-target block format, match anchor, ordering rule, and unmatched behavior |
+| `docs/specs/git-operations.md` | Clarify that target matching anchors on the repository main worktree root used for git operations |
+| `docs/project-plan.md` | Mark FR-28 status only if this child plan completes the full matching contract |
+
+## Design Decision Changes
+
+| File | Change |
+|------|--------|
+| `docs/design-decisions/adr.md` | Append ADR for project-target matching anchor and selection rule if the foundation ADR does not already cover it |
+
+## Code Changes
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Extend the global config schema and selection logic for project-target blocks |
+| `internal/config/config_test.go` | Add target-matching tests, including overlapping and unmatched cases |
+| `cmd/ww/main.go` | Ensure the matched project layer resolves before the manager config is finalized |
+
+## Test Changes
+
+- Add tests proving:
+  - matching uses the main worktree root as the stable anchor
+  - first matching project block wins
+  - unmatched blocks leave the base global config unchanged
+  - invalid project-target definitions fail clearly instead of silently half-applying
+
+## Design Notes
+
+- The target anchor must be stable across `ww create`, `ww cd`, and invocation from secondary worktrees; the repository main root is the least surprising anchor.
+- Avoid implicit multi-match merging in this phase. One selected project block is easier to explain and debug.
+- Keep the initial matcher expressive enough for path-based reuse, but do not invent a broad policy DSL.
+
+## Sub-tasks
+
+- [ ] [parallel] Specify the project-target syntax and first-match-wins rule in `docs/specs/configuration.md`
+- [ ] [parallel] Decide whether `docs/specs/git-operations.md` needs an explicit anchor clarification
+- [ ] [depends on: 0028 foundation] Implement project-target parsing and selection in `internal/config`
+- [ ] [depends on: implementation] Thread selected project settings into final manager config resolution
+- [ ] [depends on: implementation] Add regression tests for overlapping rules, unmatched targets, and secondary-worktree invocation
+
+## Verification
+
+- `go test ./internal/config ./cmd/ww`
+- Manual verification:
+  - one global config applies different settings to two repositories in the same workspace
+  - invoking `ww` from a secondary worktree still matches the intended project using the main repo root
+  - overlapping project rules select the first declared match consistently

--- a/docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md
+++ b/docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md
@@ -1,34 +1,32 @@
-# 0029: Phase 5 project match rules
+# 0029: Phase 5 Global Config Project Target Matching
 
-> **Execution**
-> Run `/execute-task` for this plan.
+> **Execution**: Use `/execute-task` to implement this plan.
 
-**Parent plan series**
-`0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
+**Parent plan series**: `0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
 
 ## Objective
 
-Add simple project matching on top of the Phase 5 global config base. One user config should be able to pick different settings for different repos.
+Add deterministic project-target matching on top of the Phase 5 global-config foundation so one user-owned config can apply different settings to different repositories or workspace members without relying on committed repo-local `.ww.toml` files.
 
 ## Context
 
-- `docs/project-plan.md` defines FR-28 as global project matching using the main worktree as the anchor.
-- The current config model is repo-scoped only.
-- Matching should stay simple for both humans and agents. Hidden fallback rules would work against that.
+- `docs/project-plan.md` defines FR-28 as global project-target matching using the main worktree as the stable target anchor.
+- The current config model is repository-scoped only. Once global config exists, `ww` needs a predictable way to select project-specific settings before the worktree manager runs.
+- Matching should stay simple enough for humans and agents to audit. Hidden fallback behavior or ambiguous best-match logic would conflict with the current repo-local simplicity.
 
 ## Options and Trade-offs
 
-1. **Use ordered project blocks with first-match-wins at the main worktree root (recommended)**
-   - Pros: Deterministic and easy to read.
+1. **Ordered project blocks with first-match-wins against the main worktree root (recommended)**
+   - Pros: Deterministic and easy to read. Supports intentional override ordering without inventing specificity scoring rules.
    - Cons: Large configs may require careful ordering by the user.
-2. **Use automatic most-specific-match-wins**
-   - Pros: Can reduce ordering burden.
-   - Cons: Harder to explain when two patterns overlap.
-3. **Use single exact-path match only**
+2. **Automatic most-specific-match-wins**
+   - Pros: Can reduce ordering burden in some cases.
+   - Cons: Specificity rules become another policy surface. Harder to explain when two patterns partially overlap.
+3. **Single exact-path match only**
    - Pros: Very simple.
-   - Cons: Too rigid for the portability goal.
+   - Cons: Too rigid for the portability goal. Fails the use case of sharing settings across multiple similar repositories.
 
-**Recommended option** Match project blocks in declared order against the main worktree root and stop at the first match.
+**Recommendation**: Option 1. Match global project blocks in declared order against the main worktree root and stop at the first match. Keep the initial matcher narrow and explicit; add more sophisticated selection only if real usage demands it.
 
 ## Scope
 
@@ -49,21 +47,21 @@ Add simple project matching on top of the Phase 5 global config base. One user c
 
 | File | Change |
 |------|--------|
-| `docs/specs/configuration.md` | Add the project block format, match anchor, ordering rule, and unmatched behavior |
-| `docs/specs/git-operations.md` | Clarify that target matching uses the repository main worktree root |
+| `docs/specs/configuration.md` | Add the global project-target block format, match anchor, ordering rule, and unmatched behavior |
+| `docs/specs/git-operations.md` | Clarify that target matching anchors on the repository main worktree root used for git operations |
 | `docs/project-plan.md` | Mark FR-28 status only if this child plan completes the full matching contract |
 
 ## Design Decision Changes
 
 | File | Change |
 |------|--------|
-| `docs/design-decisions/adr.md` | Add an ADR for the match anchor and selection rule if needed |
+| `docs/design-decisions/adr.md` | Append ADR for project-target matching anchor and selection rule if the foundation ADR does not already cover it |
 
 ## Code Changes
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Add project blocks to global config selection |
+| `internal/config/config.go` | Extend the global config schema and selection logic for project-target blocks |
 | `internal/config/config_test.go` | Add target-matching tests, including overlapping and unmatched cases |
 | `cmd/ww/main.go` | Ensure the matched project layer resolves before the manager config is finalized |
 
@@ -73,19 +71,19 @@ Add simple project matching on top of the Phase 5 global config base. One user c
   - matching uses the main worktree root as the stable anchor
   - first matching project block wins
   - unmatched blocks leave the base global config unchanged
-  - invalid project-target definitions fail clearly instead of half-applying
+  - invalid project-target definitions fail clearly instead of silently half-applying
 
 ## Design Notes
 
-- The target anchor must stay stable across `ww create`, `ww cd`, and runs from secondary worktrees.
-- Skip implicit multi-match merging in this phase. One selected project block is easier to explain and debug.
-- Keep the first matcher useful for path-based reuse.
+- The target anchor must be stable across `ww create`, `ww cd`, and invocation from secondary worktrees; the repository main root is the least surprising anchor.
+- Avoid implicit multi-match merging in this phase. One selected project block is easier to explain and debug.
+- Keep the initial matcher expressive enough for path-based reuse, but do not invent a broad policy DSL.
 
 ## Sub-tasks
 
 - [ ] [parallel] Specify the project-target syntax and first-match-wins rule in `docs/specs/configuration.md`
 - [ ] [parallel] Decide whether `docs/specs/git-operations.md` needs an explicit anchor clarification
-- [ ] [depends on: 0028 foundation] Add project-target parsing and selection in `internal/config`
+- [ ] [depends on: 0028 foundation] Implement project-target parsing and selection in `internal/config`
 - [ ] [depends on: implementation] Thread selected project settings into final manager config resolution
 - [ ] [depends on: implementation] Add regression tests for overlapping rules, unmatched targets, and secondary-worktree invocation
 
@@ -93,6 +91,6 @@ Add simple project matching on top of the Phase 5 global config base. One user c
 
 - `go test ./internal/config ./cmd/ww`
 - Manual verification:
-  - one global config applies different settings to two repos in the same workspace
-  - invoking `ww` from a secondary worktree still matches the intended project by using the main repo root
+  - one global config applies different settings to two repositories in the same workspace
+  - invoking `ww` from a secondary worktree still matches the intended project using the main repo root
   - overlapping project rules select the first declared match consistently

--- a/docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md
+++ b/docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md
@@ -1,32 +1,34 @@
-# 0029: Phase 5 Global Config Project Target Matching
+# 0029: Phase 5 project match rules
 
-> **Execution**: Use `/execute-task` to implement this plan.
+> **Execution**
+> Run `/execute-task` for this plan.
 
-**Parent plan series**: `0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
+**Parent plan series**
+`0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
 
 ## Objective
 
-Add deterministic project-target matching on top of the Phase 5 global-config foundation so one user-owned config can apply different settings to different repositories or workspace members without relying on committed repo-local `.ww.toml` files.
+Add simple project matching on top of the Phase 5 global config base. One user config should be able to pick different settings for different repos.
 
 ## Context
 
-- `docs/project-plan.md` defines FR-28 as global project-target matching using the main worktree as the stable target anchor.
-- The current config model is repository-scoped only. Once global config exists, `ww` needs a predictable way to select project-specific settings before the worktree manager runs.
-- Matching should stay simple enough for humans and agents to audit. Hidden fallback behavior or ambiguous best-match logic would conflict with the current repo-local simplicity.
+- `docs/project-plan.md` defines FR-28 as global project matching using the main worktree as the anchor.
+- The current config model is repo-scoped only.
+- Matching should stay simple for both humans and agents. Hidden fallback rules would work against that.
 
 ## Options and Trade-offs
 
-1. **Ordered project blocks with first-match-wins against the main worktree root (recommended)**
-   - Pros: Deterministic and easy to read. Supports intentional override ordering without inventing specificity scoring rules.
+1. **Use ordered project blocks with first-match-wins at the main worktree root (recommended)**
+   - Pros: Deterministic and easy to read.
    - Cons: Large configs may require careful ordering by the user.
-2. **Automatic most-specific-match-wins**
-   - Pros: Can reduce ordering burden in some cases.
-   - Cons: Specificity rules become another policy surface. Harder to explain when two patterns partially overlap.
-3. **Single exact-path match only**
+2. **Use automatic most-specific-match-wins**
+   - Pros: Can reduce ordering burden.
+   - Cons: Harder to explain when two patterns overlap.
+3. **Use single exact-path match only**
    - Pros: Very simple.
-   - Cons: Too rigid for the portability goal. Fails the use case of sharing settings across multiple similar repositories.
+   - Cons: Too rigid for the portability goal.
 
-**Recommendation**: Option 1. Match global project blocks in declared order against the main worktree root and stop at the first match. Keep the initial matcher narrow and explicit; add more sophisticated selection only if real usage demands it.
+**Recommended option** Match project blocks in declared order against the main worktree root and stop at the first match.
 
 ## Scope
 
@@ -47,21 +49,21 @@ Add deterministic project-target matching on top of the Phase 5 global-config fo
 
 | File | Change |
 |------|--------|
-| `docs/specs/configuration.md` | Add the global project-target block format, match anchor, ordering rule, and unmatched behavior |
-| `docs/specs/git-operations.md` | Clarify that target matching anchors on the repository main worktree root used for git operations |
+| `docs/specs/configuration.md` | Add the project block format, match anchor, ordering rule, and unmatched behavior |
+| `docs/specs/git-operations.md` | Clarify that target matching uses the repository main worktree root |
 | `docs/project-plan.md` | Mark FR-28 status only if this child plan completes the full matching contract |
 
 ## Design Decision Changes
 
 | File | Change |
 |------|--------|
-| `docs/design-decisions/adr.md` | Append ADR for project-target matching anchor and selection rule if the foundation ADR does not already cover it |
+| `docs/design-decisions/adr.md` | Add an ADR for the match anchor and selection rule if needed |
 
 ## Code Changes
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Extend the global config schema and selection logic for project-target blocks |
+| `internal/config/config.go` | Add project blocks to global config selection |
 | `internal/config/config_test.go` | Add target-matching tests, including overlapping and unmatched cases |
 | `cmd/ww/main.go` | Ensure the matched project layer resolves before the manager config is finalized |
 
@@ -71,19 +73,19 @@ Add deterministic project-target matching on top of the Phase 5 global-config fo
   - matching uses the main worktree root as the stable anchor
   - first matching project block wins
   - unmatched blocks leave the base global config unchanged
-  - invalid project-target definitions fail clearly instead of silently half-applying
+  - invalid project-target definitions fail clearly instead of half-applying
 
 ## Design Notes
 
-- The target anchor must be stable across `ww create`, `ww cd`, and invocation from secondary worktrees; the repository main root is the least surprising anchor.
-- Avoid implicit multi-match merging in this phase. One selected project block is easier to explain and debug.
-- Keep the initial matcher expressive enough for path-based reuse, but do not invent a broad policy DSL.
+- The target anchor must stay stable across `ww create`, `ww cd`, and runs from secondary worktrees.
+- Skip implicit multi-match merging in this phase. One selected project block is easier to explain and debug.
+- Keep the first matcher useful for path-based reuse.
 
 ## Sub-tasks
 
 - [ ] [parallel] Specify the project-target syntax and first-match-wins rule in `docs/specs/configuration.md`
 - [ ] [parallel] Decide whether `docs/specs/git-operations.md` needs an explicit anchor clarification
-- [ ] [depends on: 0028 foundation] Implement project-target parsing and selection in `internal/config`
+- [ ] [depends on: 0028 foundation] Add project-target parsing and selection in `internal/config`
 - [ ] [depends on: implementation] Thread selected project settings into final manager config resolution
 - [ ] [depends on: implementation] Add regression tests for overlapping rules, unmatched targets, and secondary-worktree invocation
 
@@ -91,6 +93,6 @@ Add deterministic project-target matching on top of the Phase 5 global-config fo
 
 - `go test ./internal/config ./cmd/ww`
 - Manual verification:
-  - one global config applies different settings to two repositories in the same workspace
-  - invoking `ww` from a secondary worktree still matches the intended project using the main repo root
+  - one global config applies different settings to two repos in the same workspace
+  - invoking `ww` from a secondary worktree still matches the intended project by using the main repo root
   - overlapping project rules select the first declared match consistently

--- a/docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md
+++ b/docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md
@@ -1,34 +1,32 @@
-# 0030: Phase 5 profile reuse
+# 0030: Phase 5 Global Config Materialization Profiles
 
-> **Execution**
-> Run `/execute-task` for this plan.
+> **Execution**: Use `/execute-task` to implement this plan.
 
-**Parent plan series**
-`0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
+**Parent plan series**: `0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
 
 ## Objective
 
-Add reusable profiles on top of the Phase 5 global config base. Users should be able to define common worktree setup once and reuse it across repos.
+Add reusable materialization profiles on top of the Phase 5 global-config foundation so users can centrally define common worktree setup patterns such as copy/symlink selections and hook-driven setup flows without committing the same `.ww.toml` payload into every repository.
 
 ## Context
 
-- `docs/project-plan.md` defines FR-29 as hook-driven profiles for sandbox-friendly setup patterns.
-- After Phase 5-01 and Phase 5-02, `ww` will have layered config and deterministic project selection.
-- Profiles touch hooks and file/link setup, so the design must keep the agreed full-override model.
+- `docs/project-plan.md` defines FR-29 as hook-driven materialization profiles for sandbox-friendly setup patterns.
+- After Phase 5-01 and Phase 5-02, `ww` will have a layered config source and deterministic project selection. This child plan uses that foundation to reduce repetition in real worktree-setup workflows.
+- Materialization profiles interact directly with hooks and file/link setup, so the design must preserve the agreed full-override model and avoid hidden composition.
 
 ## Options and Trade-offs
 
-1. **Use one named profile per project with full expansion (recommended)**
-   - Pros: Keeps the runtime model simple.
+1. **Named single-profile selection per project with explicit full expansion (recommended)**
+   - Pros: Keeps the runtime model simple. One chosen profile expands to ordinary config values before command execution.
    - Cons: Users cannot stack multiple profiles implicitly.
-2. **Combine multiple profiles in order**
+2. **Multiple profiles combined in order**
    - Pros: More flexible for advanced reuse.
-   - Cons: Reintroduces the same merge and append ambiguity avoided in Phase 5-01.
-3. **Skip profiles and repeat per-project config**
+   - Cons: Reintroduces the same merge/append ambiguity Phase 5-01 deliberately avoided.
+3. **No profile concept, only repeated per-project config**
    - Pros: Smallest implementation.
-   - Cons: Misses the portability goal.
+   - Cons: Misses the stated portability goal and keeps global config noisy and repetitive.
 
-**Recommended option** Allow one explicit profile selection that expands to normal config values.
+**Recommendation**: Option 1. Allow one explicit profile selection that expands to normal config values, with the existing complete-override semantics still applying at the final selected layer.
 
 ## Scope
 
@@ -49,7 +47,7 @@ Add reusable profiles on top of the Phase 5 global config base. Users should be 
 
 | File | Change |
 |------|--------|
-| `docs/specs/configuration.md` | Add named profile syntax, reference rules, expansion rules, and invalid-reference behavior |
+| `docs/specs/configuration.md` | Add named profile syntax, reference rules, expansion semantics, and invalid-reference behavior |
 | `docs/specs/cli-commands.md` | Document any CLI-visible output or diagnostics affected by profile expansion |
 | `docs/project-plan.md` | Mark FR-29 status only if this child plan fully lands profile support |
 
@@ -57,13 +55,13 @@ Add reusable profiles on top of the Phase 5 global config base. Users should be 
 
 | File | Change |
 |------|--------|
-| `docs/design-decisions/adr.md` | Add an ADR if needed to record why one profile was chosen over stacked composition |
+| `docs/design-decisions/adr.md` | Append ADR if needed to record why single-profile expansion was chosen over stacked profile composition |
 
 ## Code Changes
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Add named materialization profiles to config resolution |
+| `internal/config/config.go` | Extend config schema and resolution for named materialization profiles |
 | `internal/config/config_test.go` | Add profile expansion and invalid-reference tests |
 | `cmd/ww/main.go` | Use the fully resolved config produced by profile expansion without changing command-level behavior |
 | `worktree/worktree.go` | Consume the resolved copy/symlink/hook values without new runtime policy branching |
@@ -78,14 +76,14 @@ Add reusable profiles on top of the Phase 5 global config base. Users should be 
 
 ## Design Notes
 
-- Profiles should stay as resolution-time sugar.
+- Profiles should be resolution-time sugar, not a second execution policy layer inside `worktree.Manager`.
 - Preserve the current trust boundary: if a selected profile defines a hook, that hook is still trusted config authored by the user.
-- Skip multiple-profile composition in this phase. If users eventually need composition, add it as an explicit design.
+- Do not combine multiple profiles in this phase. If users eventually need composition, it should be explicit and separately designed.
 
 ## Sub-tasks
 
 - [ ] [parallel] Specify named profile syntax and expansion semantics in `docs/specs/configuration.md`
-- [ ] [depends on: 0028 foundation and 0029 target matching] Add profile parsing and single-profile expansion in `internal/config`
+- [ ] [depends on: 0028 foundation and 0029 target matching] Implement profile parsing and single-profile expansion in `internal/config`
 - [ ] [depends on: implementation] Ensure command setup consumes only fully resolved config values
 - [ ] [depends on: implementation] Add regression tests for valid expansion, invalid references, and no-profile compatibility
 - [ ] [depends on: verification] Update `docs/project-plan.md` status markers if FR-29 is fully complete

--- a/docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md
+++ b/docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md
@@ -1,0 +1,97 @@
+# 0030: Phase 5 Global Config Materialization Profiles
+
+> **Execution**: Use `/execute-task` to implement this plan.
+
+**Parent plan series**: `0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
+
+## Objective
+
+Add reusable materialization profiles on top of the Phase 5 global-config foundation so users can centrally define common worktree setup patterns such as copy/symlink selections and hook-driven setup flows without committing the same `.ww.toml` payload into every repository.
+
+## Context
+
+- `docs/project-plan.md` defines FR-29 as hook-driven materialization profiles for sandbox-friendly setup patterns.
+- After Phase 5-01 and Phase 5-02, `ww` will have a layered config source and deterministic project selection. This child plan uses that foundation to reduce repetition in real worktree-setup workflows.
+- Materialization profiles interact directly with hooks and file/link setup, so the design must preserve the agreed full-override model and avoid hidden composition.
+
+## Options and Trade-offs
+
+1. **Named single-profile selection per project with explicit full expansion (recommended)**
+   - Pros: Keeps the runtime model simple. One chosen profile expands to ordinary config values before command execution.
+   - Cons: Users cannot stack multiple profiles implicitly.
+2. **Multiple profiles combined in order**
+   - Pros: More flexible for advanced reuse.
+   - Cons: Reintroduces the same merge/append ambiguity Phase 5-01 deliberately avoided.
+3. **No profile concept, only repeated per-project config**
+   - Pros: Smallest implementation.
+   - Cons: Misses the stated portability goal and keeps global config noisy and repetitive.
+
+**Recommendation**: Option 1. Allow one explicit profile selection that expands to normal config values, with the existing complete-override semantics still applying at the final selected layer.
+
+## Scope
+
+### In Scope
+
+- Define the reusable profile format and where it can be referenced
+- Specify how a selected profile expands into ordinary config fields
+- Keep hook/copy/symlink behavior consistent with the full-override rule
+- Add tests for profile selection, expansion, and invalid references
+
+### Out of Scope
+
+- Multi-profile stacking or additive profile composition
+- Hook trust hardening beyond the existing trusted-config model
+- New hook lifecycle phases; those belong to Phase 6
+
+## Spec Changes
+
+| File | Change |
+|------|--------|
+| `docs/specs/configuration.md` | Add named profile syntax, reference rules, expansion semantics, and invalid-reference behavior |
+| `docs/specs/cli-commands.md` | Document any CLI-visible output or diagnostics affected by profile expansion |
+| `docs/project-plan.md` | Mark FR-29 status only if this child plan fully lands profile support |
+
+## Design Decision Changes
+
+| File | Change |
+|------|--------|
+| `docs/design-decisions/adr.md` | Append ADR if needed to record why single-profile expansion was chosen over stacked profile composition |
+
+## Code Changes
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Extend config schema and resolution for named materialization profiles |
+| `internal/config/config_test.go` | Add profile expansion and invalid-reference tests |
+| `cmd/ww/main.go` | Use the fully resolved config produced by profile expansion without changing command-level behavior |
+| `worktree/worktree.go` | Consume the resolved copy/symlink/hook values without new runtime policy branching |
+
+## Test Changes
+
+- Add tests proving:
+  - a selected profile expands into ordinary config values before create/list/remove behavior runs
+  - invalid profile references fail clearly
+  - profile-provided arrays and hooks still obey full replacement semantics
+  - repositories without profiles behave exactly as before
+
+## Design Notes
+
+- Profiles should be resolution-time sugar, not a second execution policy layer inside `worktree.Manager`.
+- Preserve the current trust boundary: if a selected profile defines a hook, that hook is still trusted config authored by the user.
+- Do not combine multiple profiles in this phase. If users eventually need composition, it should be explicit and separately designed.
+
+## Sub-tasks
+
+- [ ] [parallel] Specify named profile syntax and expansion semantics in `docs/specs/configuration.md`
+- [ ] [depends on: 0028 foundation and 0029 target matching] Implement profile parsing and single-profile expansion in `internal/config`
+- [ ] [depends on: implementation] Ensure command setup consumes only fully resolved config values
+- [ ] [depends on: implementation] Add regression tests for valid expansion, invalid references, and no-profile compatibility
+- [ ] [depends on: verification] Update `docs/project-plan.md` status markers if FR-29 is fully complete
+
+## Verification
+
+- `go test ./internal/config ./cmd/ww ./worktree`
+- Manual verification:
+  - one global profile can be reused by multiple project-target blocks
+  - the resolved create behavior matches the expanded `copy_files`, `symlink_files`, and `post_create_hook` values
+  - invalid profile references fail with an actionable error

--- a/docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md
+++ b/docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md
@@ -1,32 +1,34 @@
-# 0030: Phase 5 Global Config Materialization Profiles
+# 0030: Phase 5 profile reuse
 
-> **Execution**: Use `/execute-task` to implement this plan.
+> **Execution**
+> Run `/execute-task` for this plan.
 
-**Parent plan series**: `0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
+**Parent plan series**
+`0028-phase5-global-config-01-foundation.md` -> `0029-phase5-global-config-02-project-target-matching.md` -> `0030-phase5-global-config-03-materialization-profiles.md`
 
 ## Objective
 
-Add reusable materialization profiles on top of the Phase 5 global-config foundation so users can centrally define common worktree setup patterns such as copy/symlink selections and hook-driven setup flows without committing the same `.ww.toml` payload into every repository.
+Add reusable profiles on top of the Phase 5 global config base. Users should be able to define common worktree setup once and reuse it across repos.
 
 ## Context
 
-- `docs/project-plan.md` defines FR-29 as hook-driven materialization profiles for sandbox-friendly setup patterns.
-- After Phase 5-01 and Phase 5-02, `ww` will have a layered config source and deterministic project selection. This child plan uses that foundation to reduce repetition in real worktree-setup workflows.
-- Materialization profiles interact directly with hooks and file/link setup, so the design must preserve the agreed full-override model and avoid hidden composition.
+- `docs/project-plan.md` defines FR-29 as hook-driven profiles for sandbox-friendly setup patterns.
+- After Phase 5-01 and Phase 5-02, `ww` will have layered config and deterministic project selection.
+- Profiles touch hooks and file/link setup, so the design must keep the agreed full-override model.
 
 ## Options and Trade-offs
 
-1. **Named single-profile selection per project with explicit full expansion (recommended)**
-   - Pros: Keeps the runtime model simple. One chosen profile expands to ordinary config values before command execution.
+1. **Use one named profile per project with full expansion (recommended)**
+   - Pros: Keeps the runtime model simple.
    - Cons: Users cannot stack multiple profiles implicitly.
-2. **Multiple profiles combined in order**
+2. **Combine multiple profiles in order**
    - Pros: More flexible for advanced reuse.
-   - Cons: Reintroduces the same merge/append ambiguity Phase 5-01 deliberately avoided.
-3. **No profile concept, only repeated per-project config**
+   - Cons: Reintroduces the same merge and append ambiguity avoided in Phase 5-01.
+3. **Skip profiles and repeat per-project config**
    - Pros: Smallest implementation.
-   - Cons: Misses the stated portability goal and keeps global config noisy and repetitive.
+   - Cons: Misses the portability goal.
 
-**Recommendation**: Option 1. Allow one explicit profile selection that expands to normal config values, with the existing complete-override semantics still applying at the final selected layer.
+**Recommended option** Allow one explicit profile selection that expands to normal config values.
 
 ## Scope
 
@@ -47,7 +49,7 @@ Add reusable materialization profiles on top of the Phase 5 global-config founda
 
 | File | Change |
 |------|--------|
-| `docs/specs/configuration.md` | Add named profile syntax, reference rules, expansion semantics, and invalid-reference behavior |
+| `docs/specs/configuration.md` | Add named profile syntax, reference rules, expansion rules, and invalid-reference behavior |
 | `docs/specs/cli-commands.md` | Document any CLI-visible output or diagnostics affected by profile expansion |
 | `docs/project-plan.md` | Mark FR-29 status only if this child plan fully lands profile support |
 
@@ -55,13 +57,13 @@ Add reusable materialization profiles on top of the Phase 5 global-config founda
 
 | File | Change |
 |------|--------|
-| `docs/design-decisions/adr.md` | Append ADR if needed to record why single-profile expansion was chosen over stacked profile composition |
+| `docs/design-decisions/adr.md` | Add an ADR if needed to record why one profile was chosen over stacked composition |
 
 ## Code Changes
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Extend config schema and resolution for named materialization profiles |
+| `internal/config/config.go` | Add named materialization profiles to config resolution |
 | `internal/config/config_test.go` | Add profile expansion and invalid-reference tests |
 | `cmd/ww/main.go` | Use the fully resolved config produced by profile expansion without changing command-level behavior |
 | `worktree/worktree.go` | Consume the resolved copy/symlink/hook values without new runtime policy branching |
@@ -76,14 +78,14 @@ Add reusable materialization profiles on top of the Phase 5 global-config founda
 
 ## Design Notes
 
-- Profiles should be resolution-time sugar, not a second execution policy layer inside `worktree.Manager`.
+- Profiles should stay as resolution-time sugar.
 - Preserve the current trust boundary: if a selected profile defines a hook, that hook is still trusted config authored by the user.
-- Do not combine multiple profiles in this phase. If users eventually need composition, it should be explicit and separately designed.
+- Skip multiple-profile composition in this phase. If users eventually need composition, add it as an explicit design.
 
 ## Sub-tasks
 
 - [ ] [parallel] Specify named profile syntax and expansion semantics in `docs/specs/configuration.md`
-- [ ] [depends on: 0028 foundation and 0029 target matching] Implement profile parsing and single-profile expansion in `internal/config`
+- [ ] [depends on: 0028 foundation and 0029 target matching] Add profile parsing and single-profile expansion in `internal/config`
 - [ ] [depends on: implementation] Ensure command setup consumes only fully resolved config values
 - [ ] [depends on: implementation] Add regression tests for valid expansion, invalid references, and no-profile compatibility
 - [ ] [depends on: verification] Update `docs/project-plan.md` status markers if FR-29 is fully complete


### PR DESCRIPTION
## Plan / Issues

- **Plan**:
  - `docs/exec-plan/todo/0028-phase5-global-config-01-foundation.md`
  - `docs/exec-plan/todo/0029-phase5-global-config-02-project-target-matching.md`
  - `docs/exec-plan/todo/0030-phase5-global-config-03-materialization-profiles.md`
- **Issues**: N/A

## Closes

N/A

## Type of Change

- [ ] Project Plan update
- [x] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `$plan-execution wwのww/docs/project-plan.md をもとに、Phase 5の計画をする。`

### Additional Context from Instructing Human

- AI proposed splitting Phase 5 into ordered child plans instead of one large plan. Human approved the split.
- Human specified the global config location rule: default to `$HOME/.config/ww/config.toml`, but use `$XDG_CONFIG_HOME/ww/config.toml` when `XDG_CONFIG_HOME` is set.
- Human specified precedence and merge behavior: repo-local config discovered by the existing search rules has higher priority than global config, and matching keys must override completely rather than append or partially merge.
- AI asked whether any current config fields should default to append semantics. Human direction was to avoid append unless a concrete need appears. The plan therefore keeps full override semantics for hooks, arrays, and other fields.

## Verification

- [ ] Tests pass (command: `N/A - planning docs only`)
- [ ] Lint passes (command: `N/A - planning docs only`)
- [x] Manual verification (describe below)

Manual verification:
- Reviewed `docs/project-plan.md`, `docs/design-decisions/core-beliefs.md`, `docs/design-decisions/adr.md`, and the current config/spec implementation before drafting the plans.
- Checked that the three new plan files share the `plan/phase5-global-config` branch base name and cover the full Phase 5 scope in order: foundation -> project target matching -> materialization profiles.
- Confirmed the agreed global config path and full-override precedence model are captured in the foundation child plan.

## Checklist

- [x] Branch created from latest `origin/main`
- [ ] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo/` to `done/` — _if executing a plan_
- [ ] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] External GitHub issues declared in the plan's `Addresses:` line are linked under `Issues`, and implementation PRs include matching `Closes` entries or explain why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [ ] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- The main review point is the Phase 5 decomposition and the chosen config-layering model in `0028`.
- `0029` and `0030` intentionally keep matching/profile behavior simple and deterministic to avoid introducing implicit merge rules too early.

## Links

N/A

## Breaking Changes

N/A
