### PR TITLE
fix: clear inherited upstream on worktree create

### DIFF
--- a/docs/exec-plan/done/0031-create-without-base-upstream.md
+++ b/docs/exec-plan/done/0031-create-without-base-upstream.md
@@ -1,0 +1,30 @@
+# Create Without Base Upstream
+
+**Execution**: direct small bug fix
+
+## Objective
+
+Prevent `ww create <branch>` from leaving a newly created local branch tracking
+the base ref used only for branch creation, such as `origin/main`.
+
+Addresses: https://github.com/yoskeoka/ww/issues/260
+
+## Spec Changes
+
+- clarify in `docs/specs/cli-commands.md` that normal new-branch creation must
+  not leave the new branch tracking the base branch
+- document the follow-up `git branch --unset-upstream <branch>` behavior in
+  `docs/specs/git-operations.md`
+
+## Code Changes
+
+- add a `git.Runner` helper that removes upstream only when one exists
+- call that helper after `git worktree add -b ... <base>` in the normal
+  new-branch creation path
+- leave existing-branch and `--guess-remote` paths unchanged
+
+## Verification
+
+- `go test ./...`
+- `make test`
+- `make lint`

--- a/docs/specs/cli-commands.md
+++ b/docs/specs/cli-commands.md
@@ -81,6 +81,8 @@ The built-in help for `ww create` must preserve the create-vs-cd role split:
    - if Git cannot resolve a matching remote branch, surface an actionable error explaining that no matching remote branch could be resolved after refreshing `origin`
    - if the installed Git does not support `git worktree add --guess-remote`, surface the original Git error, tell the user to upgrade Git, and include a manual `git worktree add -b <branch> --track <path> origin/<branch>` fallback
 5. Otherwise: create a new branch from `default_base` (config), `origin/HEAD`, or the heuristic `origin/main` / `origin/master` fallback and add a worktree for it.
+   - the created local branch must not keep an upstream that points at the base branch used only for branch creation
+   - example: if `ww create feat/x` creates `feat/x` from `origin/main`, the new local `feat/x` branch must end up with no upstream instead of tracking `origin/main`
 6. After worktree creation, copy files listed in `copy_files` config.
 7. Create symlinks for files listed in `symlink_files` config.
 8. Run `post_create_hook` if configured. In text mode, print `Running post_create_hook: <command>` immediately before streaming the hook's own output.

--- a/docs/specs/git-operations.md
+++ b/docs/specs/git-operations.md
@@ -44,7 +44,14 @@ This excludes linked worktree checkouts while still allowing valid standalone re
 **Create worktree with new branch:**
 ```
 git worktree add -b <branch> <path> <base>
+git branch --unset-upstream <branch>
 ```
+
+Git may automatically record `<base>` as the new branch's upstream when `<base>`
+is a remote-tracking ref such as `origin/main`. `ww` uses that ref only as the
+branch creation start-point, so after creating a new local branch from a base
+ref it must remove that auto-created upstream. This keeps normal `ww create
+<branch>` output from leaving the new branch tracking `origin/main` by mistake.
 
 **Create worktree for existing branch:**
 ```

--- a/git/git.go
+++ b/git/git.go
@@ -72,6 +72,23 @@ func (r *Runner) WorktreeAdd(path, branch, base string) error {
 	return err
 }
 
+// BranchUnsetUpstream removes any upstream configured for branch.
+func (r *Runner) BranchUnsetUpstream(branch string) error {
+	remote, err := r.BranchRemote(branch)
+	if err != nil {
+		return err
+	}
+	mergeRef, err := r.BranchMergeRef(branch)
+	if err != nil {
+		return err
+	}
+	if remote == "" && mergeRef == "" {
+		return nil
+	}
+	_, err = r.Run("branch", "--unset-upstream", branch)
+	return err
+}
+
 // WorktreeAddGuessRemote creates a worktree by asking Git to resolve a
 // same-named remote branch.
 func (r *Runner) WorktreeAddGuessRemote(path, branch string) error {

--- a/worktree/worktree.go
+++ b/worktree/worktree.go
@@ -216,6 +216,9 @@ func (m *Manager) Create(branch string, opts CreateOpts) (*WorktreeInfo, []strin
 		if err := m.Git.WorktreeAdd(wtPath, branch, base); err != nil {
 			return nil, nil, fmt.Errorf("creating worktree with new branch: %w", err)
 		}
+		if err := m.Git.BranchUnsetUpstream(branch); err != nil {
+			return nil, nil, fmt.Errorf("clearing inherited upstream for new branch: %w", err)
+		}
 	}
 
 	m.copyFiles(wtPath)

--- a/worktree/worktree_test.go
+++ b/worktree/worktree_test.go
@@ -554,6 +554,13 @@ func TestCreateNewBranchDoesNotTrackBaseRemoteBranch(t *testing.T) {
 		Config:  Config{},
 		RepoDir: repo,
 	}
+	baseInfo, err := mgr.baseRef(runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseInfo.Ref != "origin/main" {
+		t.Fatalf("baseRef().Ref = %q, want %q", baseInfo.Ref, "origin/main")
+	}
 
 	info, _, err := mgr.Create("feat/no-upstream", CreateOpts{})
 	if err != nil {

--- a/worktree/worktree_test.go
+++ b/worktree/worktree_test.go
@@ -545,6 +545,29 @@ func TestCreateSandboxSingleRepoUsesRepoLocalWorktrees(t *testing.T) {
 	}
 }
 
+func TestCreateNewBranchDoesNotTrackBaseRemoteBranch(t *testing.T) {
+	repo, _ := setupGitRepoWithRemote(t)
+	runner := &git.Runner{Dir: repo}
+
+	mgr := &Manager{
+		Git:     runner,
+		Config:  Config{},
+		RepoDir: repo,
+	}
+
+	info, _, err := mgr.Create("feat/no-upstream", CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracking, err := runner.BranchTrackingConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg, ok := tracking["feat/no-upstream"]; ok && (cfg.Remote != "" || cfg.MergeRef != "") {
+		t.Fatalf("tracking[feat/no-upstream] = %+v, want no upstream after creating %s", cfg, info.Path)
+	}
+}
+
 func TestCreateSandboxRelativeEscapeRejected(t *testing.T) {
 	repo := filepath.Join(t.TempDir(), "repo")
 	if err := os.MkdirAll(repo, 0755); err != nil {


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `docs/exec-plan/done/0031-create-without-base-upstream.md`
- **Issues**: `https://github.com/yoskeoka/ww/issues/260`

## Closes

Closes #260

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [ ] Chore (CI, tooling, deps)

## Change Summary

- reproduce that `git worktree add -b <branch> <path> origin/main` leaves the new branch tracking `origin/main`
- clear that inherited upstream only in the normal new-branch creation path
- document the behavior and add regression coverage for create-from-base worktrees

## Human Instructions / Intent

Human instruction: `Investigate whether ww intentionally makes newly created worktree branches track origin/main, or whether this is a git worktree side effect, and if possible apply the smallest fix so created worktrees do not track origin/main.`
### Additional Context from Instructing Human

- The user explicitly suggested that the minimal viable fix might be appending `--unset-upstream` at the end if that matched the root cause.

## Verification

- [x] Tests pass (command: `go test ./...`)
- [x] Lint passes (command: `make lint`)
- [x] Manual verification (describe below)

Manual verification:
- Reproduced in a temp repo that raw `git worktree add -b feat/test <path> origin/main` writes `branch.feat/test.remote=origin` and `branch.feat/test.merge=refs/heads/main`.
- Reproduced that `git branch --unset-upstream feat/test` clears that inherited tracking without affecting the checked-out worktree.
- Confirmed `make test` also passes.

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [x] Plan moved from `todo/` to `done/` — _if executing a plan_
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] External GitHub issues declared in the plan's `Addresses:` line are linked under `Issues`, and implementation PRs include matching `Closes` entries or explain why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` — _if discovered during work_
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- `--guess-remote` intentionally still tracks the same-named remote branch; this change only affects the normal new-branch-from-base path.

## Links

- `https://github.com/yoskeoka/ww/issues/260`

## Breaking Changes

N/A

## Screenshots / Logs

- `go test ./...`
- `make test`
- `make lint`
