### PR TITLE
plan: split list and clean performance refactors

### DIFF
--- a/docs/exec-plan/todo/0038-list-clean-performance-01-discovery-reuse.md
+++ b/docs/exec-plan/todo/0038-list-clean-performance-01-discovery-reuse.md
@@ -1,0 +1,147 @@
+# List/Clean Performance 01: Reuse Workspace Discovery Results
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Reduce command-startup work shared by `ww list` and `ww clean` by reusing
+workspace discovery results within one invocation. Preserve the accepted
+nearest-containing-workspace algorithm, sandbox boundary, repository ordering,
+no-follow symlink rule, linked-worktree exclusion, and error behavior.
+
+Completion means repeated scans of the same candidate directory and redundant
+main-worktree resolution are removed, the detected `Workspace` is unchanged for
+all covered layouts, and the command-boundary benchmarks introduced by
+[PR #280](https://github.com/yoskeoka/ww/pull/280) show before/after medians for
+both commands on the same host and fixture.
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Static Analysis Findings
+
+- `DetectWithOptions` scans `absStart` before it knows whether the start path is
+  in Git, then `detectContainingWorkspace` can scan that same directory again.
+- `isContainingWorkspaceRoot` scans each qualifying candidate to decide whether
+  it contains enough repositories, and `reposAtWorkspaceRoot` scans the winning
+  root again to construct the returned repository list.
+- `scanImmediateRepos` sends every immediate child directory through
+  `isStandaloneRepoRoot`; a surviving candidate can execute top-level,
+  git-dir, and common-dir Git queries even when a cheap `.git` marker check
+  could reject it first. Presence of a marker must remain insufficient by
+  itself: stray markers still require full Git validation.
+- `newManagerWithOptions` resolves the main worktree for pre-config project
+  matching, `workspace.DetectWithOptions` resolves it again, and
+  `loadManagerContext` resolves it once more. The first lookup remains needed
+  before sandbox mode is known, but the detection result can carry enough
+  context to avoid the final duplicate lookup.
+- These costs occur before `Manager.List`, so they remain plausible contributors
+  even if status calculation is later proven dominant.
+
+## Existing Implementation References
+
+- `workspace/workspace.go`
+  - `DetectWithOptions`, lines 51-129: initial child scan, main-root resolution,
+    sandbox split, and containing-workspace selection.
+  - `detectContainingWorkspace` / `isContainingWorkspaceRoot`, lines 131-205:
+    bounded candidate traversal and candidate qualification scans.
+  - `reposAtWorkspaceRoot` / `scanImmediateRepos`, lines 207-236: final repo
+    enumeration and immediate-child validation dispatch.
+  - `isStandaloneRepoRoot`, lines 288-333: three Git-backed checks that preserve
+    real-repository and linked-worktree semantics.
+- `cmd/ww/main.go`
+  - `newManagerWithOptions`, lines 142-195: pre-config main-root lookup and
+    optional sandbox re-resolution.
+  - `loadManagerContext`, lines 197-224: workspace detection followed by another
+    main-worktree lookup.
+- `workspace/workspace_test.go`, lines 25-298: standalone, workspace, symlink,
+  unreadable-entry, and cheap-prefilter coverage.
+- `docs/specs/workspace-discovery.md`, lines 30-80: bounded discovery, sandbox,
+  and immediate-child behavior that must not change.
+- `docs/specs/testing.md`, lines 12-27: the existing command-boundary benchmark
+  and scalable fixture contract.
+- `internal/testutil/performance_fixture.go`, lines 12-165: the versioned
+  repository/worktree scale used by the benchmark.
+
+## Code Change Map
+
+- `workspace/workspace.go` (MODIFY)
+  - Introduce an invocation-local discovery context that caches normalized
+    `scanImmediateRepos` results by absolute candidate path.
+  - Return defensive slice copies so appending the workspace root repository or
+    normalizing results cannot mutate a cached candidate result.
+  - Add a cheap, no-follow `.git` marker eligibility check after the existing
+    `DirEntry` classification and before Git validation. Continue to validate
+    every surviving marker with top-level/git-dir/common-dir checks.
+  - Preserve missing-entry and permission-error handling and do not introduce a
+    process-global cache whose repository set could become stale.
+  - Expose detection context internally or additively so the already-resolved
+    current main root can be reused by manager construction without changing
+    `Detect` / `DetectWithOptions` callers.
+- `workspace/workspace_test.go` (MODIFY)
+  - Prove the same candidate is scanned once per detection invocation.
+  - Prove returned repo slices do not alias cached state.
+  - Cover real repos, linked worktrees, stray/partial `.git` markers, symlink
+    children, disappearing entries, permission failures, and non-repo
+    directories rejected before Git validation.
+- `cmd/ww/main.go` (MODIFY)
+  - Consume the detection result's main-root context in `loadManagerContext`.
+  - Keep the pre-config lookup and the existing sandbox-config rerun semantics.
+- `cmd/ww/config_test.go` (MODIFY)
+  - Add regression coverage that repo-local/global project matching and
+    config-enabled sandbox reruns resolve exactly as before.
+- `integration_test.go` (MODIFY)
+  - Retain end-to-end coverage for child-repo, git-backed workspace-root,
+    non-git workspace-root, nearest parent/grandparent, and sandbox entry paths.
+
+## Spec Changes
+
+N/A - this is a behavior-preserving refactor. The black-box discovery contract
+in `docs/specs/workspace-discovery.md` and the performance measurement contract
+in `docs/specs/testing.md` remain authoritative and must pass unchanged.
+
+## Sub-tasks
+
+1. Capture current-main evidence
+   - Run `make perf-check` and retain all three samples and medians for
+     `BenchmarkWorkspaceList` and `BenchmarkWorkspaceCleanDryRun`.
+   - Run the same benchmark command with a higher repository count using the
+     existing `WW_PERF_REPOS` override to amplify discovery cost.
+   - Collect `make perf-profile PERF_PROFILE_DIR=<path>` output before changing
+     discovery and record whether startup/process work is visible.
+2. Reuse discovery work
+   - Add the invocation-local scan context, defensive copies, and cheap marker
+     prefilter.
+   - Thread the detected main root into manager initialization while preserving
+     pre-config and sandbox rerun behavior.
+3. Prove behavior and improvement
+   - Add unit/integration regressions for every discovery boundary above.
+   - Re-run the exact default and repository-heavy measurements on the same
+     host. Record before/after samples in the implementation PR.
+   - Do not land the refactor as a performance change if the target measurement
+     does not improve outside the captured pre-change run-to-run range; keep
+     any independently valuable correctness-neutral cleanup separately scoped.
+
+## Dependencies and Parallelism
+
+- This plan and `0039-list-clean-performance-02-tracking-batch.md` touch separate
+  primary packages and may be executed independently.
+- Complete this plan before bounded cross-repository parallelism so the later
+  plan does not hide redundant discovery work behind concurrency.
+- Do not combine patch-equivalence or clean-removal changes into this plan.
+
+## Verification
+
+- `go test ./workspace ./cmd/ww`
+- `go test ./...`
+- `go test -race ./workspace ./cmd/ww`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run the versioned benchmark command with the same higher
+  `WW_PERF_REPOS` value before and after the change.
+- Confirm the implementation PR's GitHub-hosted performance job remains within
+  the versioned 400 ms list and 420 ms clean advisory budgets. Local runs use
+  same-host before/after samples and are not required to meet those CI-specific
+  thresholds; record PR #280's initial 258.1 ms / 269.6 ms GitHub medians only
+  as historical context.

--- a/docs/exec-plan/todo/0039-list-clean-performance-02-tracking-batch.md
+++ b/docs/exec-plan/todo/0039-list-clean-performance-02-tracking-batch.md
@@ -1,0 +1,136 @@
+# List/Clean Performance 02: Batch Branch Tracking Metadata
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Replace per-worktree branch-remote Git subprocesses in the `ww list` / `ww clean`
+status path with one repository-scoped tracking metadata query. Preserve status
+values, `merged > stale` precedence, remote-gone behavior, local-only active
+behavior, error handling, and output ordering.
+
+Completion means branch tracking metadata scales with repositories rather than
+worktrees, all existing status scenarios remain byte-for-byte compatible at the
+CLI boundary, and the PR records before/after medians from the command-boundary
+benchmarks introduced by [PR #280](https://github.com/yoskeoka/ww/pull/280).
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Static Analysis Findings
+
+- `listRepo` already batches remote branch existence to one `ls-remote --heads`
+  per unique remote within a repository.
+- Before that batch, it calls `BranchRemote` once for every non-main,
+  non-merged worktree branch. `BranchRemote` shells out to
+  `git config --get branch.<branch>.remote`, so this portion is O(worktrees)
+  process startup even when every branch tracks the same remote.
+- Tracking metadata is repository-local and can be read in one Git ref/config
+  query, then projected back onto the existing entry order. The live
+  `ls-remote` call cannot be replaced with local remote-tracking refs without
+  changing stale semantics and is outside this plan.
+- Patch-equivalence work is a separate larger source of O(worktrees/history)
+  cost and is intentionally isolated in plan 0040.
+
+## Existing Implementation References
+
+- `worktree/worktree.go`
+  - `Manager.List` / `listWorkspace`, lines 354-453: shared list/clean entry and
+    repository traversal.
+  - `listRepo`, lines 456-540: merged-set creation, per-entry `BranchRemote`
+    loop, per-remote branch listing, and final status projection.
+  - `resolveStatus`, lines 643-658: required merged/stale/active precedence.
+- `git/git.go`
+  - `BranchRemote`, lines 258-266: one config subprocess per branch.
+  - `ListRemoteBranches`, lines 298-326: existing one-call-per-remote batch and
+    parsing behavior that remains unchanged.
+- `worktree/worktree_test.go`, lines 317-540: repository-backed status cases.
+- `git/git_test.go`, lines 463-523 and nearby branch-helper coverage: real Git
+  runner behavior.
+- `docs/specs/cli-commands.md`, lines 377-441 and 503 onward: externally visible
+  status and cleanable contract.
+- `docs/specs/git-operations.md`, lines 105-153: current per-branch tracking and
+  remote existence description.
+- `docs/specs/testing.md`, lines 12-27: PR #280 benchmark/budget contract.
+
+## Code Change Map
+
+- `docs/specs/git-operations.md` (MODIFY)
+  - Describe repository-scoped bulk tracking metadata resolution while
+    preserving the meaning of configured remote names and live remote branch
+    existence checks.
+- `git/git.go` (MODIFY)
+  - Add a batch helper that returns branch-to-remote tracking metadata for the
+    requested local branches with one Git subprocess.
+  - Read the configured `branch.<name>.remote` values in bulk rather than
+    inferring them from a resolved upstream ref; current behavior does not
+    require `branch.<name>.merge` to be present.
+  - Use a machine-parseable delimiter/format that supports slashes and unusual
+    valid branch names without whitespace ambiguity.
+  - Preserve the distinction between no configured remote and a configured
+    remote whose branch is absent.
+- `git/git_test.go` (MODIFY)
+  - Cover multiple tracked branches on one remote, multiple remotes,
+    untracked/local-only branches, a configured remote without a merge ref, a
+    configured-but-gone upstream, and branch names containing slashes.
+- `worktree/worktree.go` (MODIFY)
+  - Request tracking metadata once for the remaining non-main/non-merged
+    branches and keep the current `ListRemoteBranches` cache per unique remote.
+  - Preserve entry order and all status/error behavior.
+- `worktree/worktree_test.go` (MODIFY)
+  - Prove direct merged, patch merged, stale, local-only active, main, detached,
+    and unknown-base entries classify exactly as before.
+- `integration_test.go` (MODIFY)
+  - Retain end-to-end `ww list --cleanable` / `ww clean --dry-run` parity with
+    several worktree branches sharing one remote and branches spanning multiple
+    configured remotes.
+
+## Spec Changes
+
+- `docs/specs/git-operations.md`: update the low-level Git query contract from
+  one `git config --get` invocation per branch to a repository-scoped bulk
+  tracking query.
+- `docs/specs/cli-commands.md`: no change. Status values, precedence, output,
+  cleanable selection, and live remote-gone semantics remain unchanged.
+
+## Sub-tasks
+
+1. Capture baseline and command shape
+   - Run `make perf-check` on current main and retain samples/medians.
+   - Run the same benchmark with a higher
+     `WW_PERF_WORKTREES_PER_REPO` value to expose per-branch scaling.
+   - Confirm via profiling or a test Git wrapper that the current path invokes
+     branch tracking lookup once per eligible branch.
+2. Add and adopt the batch query
+   - Update the Git-operations spec first.
+   - Implement and test the batch parser/helper.
+   - Replace only the `BranchRemote` loop in `listRepo`; keep patch-equivalence,
+     base resolution, and live remote enumeration unchanged.
+3. Verify semantics and performance
+   - Run status unit/integration coverage and compare text/JSON output.
+   - Re-run default and worktree-heavy benchmark profiles on the same host and
+     record before/after samples in the implementation PR.
+   - If the target profile does not improve outside the baseline variation,
+     stop and use the evidence to re-evaluate this refactor before landing it.
+
+## Dependencies and Parallelism
+
+- May execute independently of plan 0038.
+- Must land before plan 0040 because both change Git/status aggregation and the
+  later plan should benchmark against the already-batched tracking path.
+- Plan 0041's bounded concurrency waits for this per-repository subprocess
+  reduction so concurrency does not multiply avoidable Git processes.
+
+## Verification
+
+- `go test ./git ./worktree`
+- `go test ./...`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run the versioned benchmark command with the same increased
+  `WW_PERF_WORKTREES_PER_REPO` value before and after.
+- Confirm the implementation PR's GitHub-hosted performance job stays within
+  the 400 ms / 420 ms advisory budgets. Use same-host samples, not those limits,
+  for local before/after judgment; PR #280's 258.1 ms / 269.6 ms medians are
+  historical GitHub-runner context only.

--- a/docs/exec-plan/todo/0040-list-clean-performance-03-patch-cache.md
+++ b/docs/exec-plan/todo/0040-list-clean-performance-03-patch-cache.md
@@ -1,0 +1,141 @@
+# List/Clean Performance 03: Amortize Patch-Equivalence Status Work
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Reduce repeated Git history and patch-id work when many non-directly-merged
+worktree branches are checked for rebase/cherry-pick/squash equivalence against
+the same base. Preserve the exact conservative `merged` classification: no
+branch may become cleanable unless its branch-intended changes are already
+integrated in the resolved base.
+
+Completion means base-side patch data is computed at most once per relevant
+merge-base within one repository listing, direct-merge and `git cherry` fast
+paths remain intact, all merge-style regressions pass, and PR #280's list and
+clean command-boundary measurements are recorded before and after the change.
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Static Analysis Findings
+
+- `PatchEquivalentBranches` iterates every candidate serially.
+- A candidate not fully integrated according to `git cherry` enters
+  `branchSquashEquivalent`, which resolves a merge-base, computes the aggregate
+  branch patch-id, lists every base commit after that merge-base, and computes a
+  patch-id for each base commit until it finds a match.
+- Worktree branches in one repository commonly share the same merge-base.
+  Current code repeats `rev-list` and base commit `show | patch-id` work for each
+  such branch, creating O(candidate branches x base history) subprocess and
+  diff work.
+- PR #280's default fixture uses empty commits for secondary branches. It
+  exercises candidate dispatch but can exit before non-empty aggregate patch
+  and base-history comparison, so the existing benchmark alone may understate
+  this hot path. A supplementary non-empty branch-shape mode is needed while
+  retaining the original default benchmark and budgets.
+
+## Existing Implementation References
+
+- `git/git.go`
+  - `PatchEquivalentBranches`, lines 152-165: serial candidate dispatch.
+  - `branchPatchEquivalent`, lines 167-178: `git cherry` fast path and squash
+    fallback.
+  - `branchSquashEquivalent`, lines 202-236: per-candidate merge-base, branch
+    aggregate, base history, and base commit patch-id loop.
+  - `diffPatchID`, lines 238-256: diff/show to stable patch-id conversion.
+- `worktree/worktree.go`, lines 478-505: selection of non-directly-merged
+  worktree branches and incorporation into the merged set.
+- `docs/specs/git-operations.md`, lines 105-137: direct, commit-equivalent, and
+  squash-equivalent merged-detection contract.
+- `docs/design-decisions/adr/0005-worktree-status-precedence.md`, lines 1-23:
+  conservative merged-before-stale decision.
+- `git/git_test.go` and `worktree/worktree_test.go`, especially the
+  patch-equivalent and status scenarios related to `PatchEquivalentBranches`.
+- `integration_test.go`, lines 2360 onward: squash/rebase cleanable CLI coverage.
+- `internal/testutil/performance_fixture.go`, lines 12-165: scalable fixture and
+  current empty-commit branch shape.
+- `cmd/ww/performance_test.go`, lines 1-77: stable list and clean benchmarks.
+- `docs/specs/testing.md`, lines 12-27: versioned default performance contract.
+
+## Code Change Map
+
+- `docs/specs/testing.md` (MODIFY)
+  - Retain the default budgeted profile unchanged.
+  - Document a supplementary, non-budgeted branch-content/profile override used
+    for patch-equivalence investigations and before/after evidence.
+- `internal/testutil/performance_fixture.go` (MODIFY)
+  - Add an opt-in fixture mode that creates deterministic non-empty branch
+    changes and enough base history to execute aggregate patch comparison.
+  - Keep the default PR #280 fixture shape and expected counts unchanged.
+- `cmd/ww/performance_test.go` (MODIFY)
+  - Consume the supplementary fixture option without renaming or weakening the
+    existing budgeted benchmark assertions.
+- `git/git.go` (MODIFY)
+  - Introduce invocation-local patch-equivalence state for a repository.
+  - Preserve the direct merged-set and `git cherry` short circuits.
+  - Cache base commit patch IDs by merge-base and compute them lazily only when
+    a candidate reaches squash-equivalence comparison.
+  - Do not create a process-global or cross-command cache; repository refs may
+    change between invocations.
+- `git/git_test.go` (MODIFY)
+  - Cover multiple candidate branches sharing a merge-base and candidates with
+    distinct merge-bases.
+  - Prove direct merge, rebase/cherry-pick equivalence, exact squash
+    equivalence, empty diff, partial integration, and extra unpublished changes.
+- `worktree/worktree_test.go` (MODIFY)
+  - Preserve merged/stale/active precedence when cached results are reused.
+- `integration_test.go` (MODIFY)
+  - Exercise multiple cleanable and non-cleanable merge styles in one repo and
+    prove `ww list --cleanable` and `ww clean --dry-run` agree.
+
+## Spec Changes
+
+- `docs/specs/testing.md`: add only the supplementary patch-heavy investigation
+  profile. The versioned default fixture, benchmark names, repetition count,
+  and budgets remain unchanged.
+- `docs/specs/cli-commands.md` and `docs/specs/git-operations.md`: no semantic
+  change. Existing conservative merge-equivalence behavior remains mandatory.
+
+## Sub-tasks
+
+1. Make the hot path measurable
+   - Add the opt-in non-empty branch-shape fixture mode as a measurement-only
+     first commit.
+   - Before implementing caching, run the default PR #280 benchmark and the new
+     patch-heavy mode repeatedly on the same host; retain samples and profiles.
+2. Cache base-side equivalence data
+   - Refactor patch-equivalence evaluation around repository-local,
+     merge-base-keyed lazy state.
+   - Keep error attribution actionable by branch/base even when cached work
+     produced the underlying failure.
+3. Prove conservative behavior and improvement
+   - Run merge-style unit/integration coverage, including negative cases.
+   - Re-run default and patch-heavy profiles with identical scale/environment.
+   - Require a patch-heavy improvement outside pre-change variation and no
+     meaningful default-profile regression before landing.
+
+## Dependencies and Parallelism
+
+- Depends on plan 0039 to avoid overlapping Git/status refactors and to measure
+  patch work after branch tracking subprocesses are already batched.
+- Must land before plan 0041 so bounded repository parallelism does not conceal
+  repeated base-history work or amplify it across repositories.
+- Fixture-mode work and negative merge-style test expansion can proceed in
+  parallel before the production cache is adopted.
+
+## Verification
+
+- `go test ./git ./worktree`
+- Targeted integration coverage for direct, rebase/cherry-pick, squash,
+  partially integrated, and extra-work branches.
+- `go test ./...`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run the documented patch-heavy profile before and after with identical repo
+  and worktree counts and record all samples in the PR.
+- Confirm the implementation PR's GitHub-hosted performance job keeps the
+  unchanged default benchmarks within 400 ms / 420 ms. Local pass/fail uses the
+  same-host before/after range; PR #280's 258.1 ms / 269.6 ms medians remain
+  historical GitHub-runner context only.

--- a/docs/exec-plan/todo/0041-list-clean-performance-04-bounded-repo-parallelism.md
+++ b/docs/exec-plan/todo/0041-list-clean-performance-04-bounded-repo-parallelism.md
@@ -1,0 +1,133 @@
+# List/Clean Performance 04: Bound and Parallelize Repository Enumeration
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Run independent repository status enumeration concurrently in workspace mode
+with a small fixed bound, while preserving deterministic repository/worktree
+output order, conservative error behavior, single-repo behavior, and all status
+semantics shared by `ww list` and `ww clean`.
+
+Completion means a slow repository no longer serially blocks every later
+repository, concurrency never becomes unbounded as workspace size grows, race
+coverage passes, and before/after measurements use the list and clean benchmarks
+introduced by [PR #280](https://github.com/yoskeoka/ww/pull/280).
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Static Analysis Findings
+
+- `listWorkspace` loops over normalized `Workspace.Repos` and calls `listRepo`
+  synchronously. Repository status computation has no shared mutable Git state;
+  each call creates a runner rooted at that repository.
+- Per-repository work includes local Git subprocesses and a live
+  `ls-remote --heads` call per unique remote. Remote latency can therefore make
+  wall time approximately additive across repositories even after local query
+  counts are reduced.
+- PR #280 uses local bare remotes, so it captures scheduling/process overhead
+  but not real network latency. It remains the required regression indicator,
+  while correctness tests with controlled delayed repository workers are needed
+  to prove concurrency deterministically.
+- Unbounded one-goroutine-per-repository execution could create a Git process
+  storm in large workspaces. A fixed small cap and indexed result slots preserve
+  both resource bounds and output order.
+
+## Existing Implementation References
+
+- `workspace/workspace.go`, lines 335-358: normalized, deterministic repository
+  ordering supplied to the manager.
+- `worktree/worktree.go`
+  - `Manager.List`, lines 354-360: single/workspace dispatch.
+  - `listWorkspace`, lines 444-454: current serial repository loop.
+  - `listRepo`, lines 456-540: independent repository-scoped status work.
+- `git/git.go`, lines 298-326: live per-repository remote enumeration that may
+  block on remote latency.
+- `cmd/ww/sub_list.go`, lines 26-73: output consumes the returned order directly.
+- `cmd/ww/sub_clean.go`, lines 58-163: clean consumes the same ordered snapshot
+  and continues per-target failures in that order.
+- `worktree/worktree_test.go`, lines 833 onward: workspace list aggregation.
+- `docs/specs/cli-commands.md`, lines 377-441 and 503 onward: deterministic
+  observable list/clean contents and shared status contract.
+- `docs/specs/testing.md`, lines 12-27: scalable PR #280 benchmark fixture.
+
+## Design Choice
+
+- Rejected: keep serial enumeration. It retains additive latency across
+  independent repositories.
+- Rejected: unbounded goroutines. It can overwhelm the host and remote servers
+  as repository count grows.
+- Chosen: a fixed small worker bound (four concurrent repositories) with one
+  result slot per original repo index. Wait for in-flight work, then return the
+  lowest-index error if any; otherwise flatten slots in original order.
+
+The bound is an internal resource policy, not a user-facing flag. A later change
+to make it configurable requires separate evidence and planning.
+
+## Code Change Map
+
+- `worktree/worktree.go` (MODIFY)
+  - Replace the serial `listWorkspace` loop with a four-worker bounded executor.
+  - Store each repository's infos/error by its original index and flatten
+    successful results in the existing order.
+  - If multiple repositories fail, return the error belonging to the earliest
+    repository in deterministic workspace order. Do not emit partial output.
+  - Keep single-repo `List` unchanged.
+- `worktree/worktree_test.go` (MODIFY)
+  - Add an internal list-repo seam or focused helper tests with controlled
+    blocking workers.
+  - Prove maximum concurrency, actual overlap, stable output order, deterministic
+    earliest error, no partial result on error, empty workspace handling, and
+    single-repo non-participation.
+- `integration_test.go` (MODIFY)
+  - Prove list/clean text and JSON ordering across multiple repositories remains
+    unchanged and all cleanable targets are retained.
+
+## Spec Changes
+
+N/A - concurrency is internal. `docs/specs/cli-commands.md` remains unchanged:
+repository/worktree order, status values, errors, and cleanable behavior are the
+same. `docs/specs/testing.md` already supports increasing `WW_PERF_REPOS` for
+this investigation.
+
+## Sub-tasks
+
+1. Capture serial baseline
+   - Run `make perf-check` and a repository-heavy benchmark profile with a fixed
+     higher `WW_PERF_REPOS` value.
+   - Retain profiles and samples after plans 0038-0040 have landed so this plan
+     measures concurrency rather than avoidable duplicate work.
+2. Add bounded scheduling
+   - Introduce the smallest testable internal seam and four-worker execution.
+   - Preserve original-index result/error collection and avoid writes to shared
+     slices without synchronization.
+3. Verify behavior, races, and improvement
+   - Run controlled concurrency tests and the race detector.
+   - Re-run default and repository-heavy benchmarks on the same host.
+   - Require repository-heavy improvement outside baseline variation and no
+     meaningful default-profile regression before landing.
+
+## Dependencies and Parallelism
+
+- Depends on plans 0038, 0039, and 0040. Concurrency is deliberately last in
+  the shared list/status path so it cannot mask or multiply redundant work.
+- Test seam design and output-order regression cases may be prepared in
+  parallel, but scheduling implementation depends on the final post-0040
+  `listRepo` signature.
+- Plan 0042 follows this plan and optimizes only clean's post-list phase.
+
+## Verification
+
+- `go test ./worktree`
+- `go test -race ./worktree`
+- `go test ./...`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run the same repository-heavy benchmark before and after.
+- Confirm stable text/JSON ordering and deterministic earliest-repo error.
+- Confirm the implementation PR's GitHub-hosted performance job keeps the
+  unchanged default benchmarks within 400 ms / 420 ms. Judge local improvement
+  against the same-host baseline; PR #280's 258.1 ms / 269.6 ms samples are
+  historical runner calibration only.

--- a/docs/exec-plan/todo/0041-list-clean-performance-04-bounded-repo-parallelism.md
+++ b/docs/exec-plan/todo/0041-list-clean-performance-04-bounded-repo-parallelism.md
@@ -35,7 +35,7 @@ Addresses: N/A - performance follow-up to the completed measurement issue
 
 ## Existing Implementation References
 
-- `workspace/workspace.go`, lines 335-358: normalized, deterministic repository
+- `workspace/workspace.go`, lines 371-400: normalized, deterministic repository
   ordering supplied to the manager.
 - `worktree/worktree.go`
   - `Manager.List`, lines 354-360: single/workspace dispatch.

--- a/docs/exec-plan/todo/0042-list-clean-performance-05-clean-snapshot-reuse.md
+++ b/docs/exec-plan/todo/0042-list-clean-performance-05-clean-snapshot-reuse.md
@@ -1,0 +1,146 @@
+# List/Clean Performance 05: Reuse Clean Snapshot for Dry-Run
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Avoid reloading the same repository config and re-running `git worktree list`
+for every cleanable target during `ww clean --dry-run`. Reuse the authoritative
+`Manager.List` snapshot only for non-mutating preview; preserve per-target
+revalidation for real removals, lifecycle-hook preview order, JSON/text output,
+failure continuation, and removal safety.
+
+Completion means dry-run post-list work scales with repositories rather than
+cleanable worktrees, real `ww clean` retains its current revalidation/mutation
+path, and PR #280's `BenchmarkWorkspaceCleanDryRun` plus the companion list
+benchmark provide recorded before/after evidence.
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Static Analysis Findings
+
+- `listCleanableWorktrees` already obtains one complete, status-bearing snapshot
+  through `Manager.List`.
+- `executeCleanWorktrees` then calls `managerForRepo` for every cleanable item.
+  In workspace mode this reloads the selected repo config, potentially twice
+  when sandbox mode must first be discovered.
+- `Manager.Remove` calls `WorktreeList` again for every target before it reaches
+  its dry-run branch. This is necessary safety for mutation, but redundant for a
+  preview based on the snapshot produced immediately above.
+- PR #280's default fixture contains one cleanable worktree per repository. It
+  measures the extra pass but does not expose repeated same-repository config
+  and worktree-list costs. An opt-in cleanable-density fixture setting is needed
+  without changing the default budgeted profile.
+
+## Existing Implementation References
+
+- `cmd/ww/sub_clean.go`
+  - `listCleanableWorktrees`, lines 58-64: authoritative status snapshot and
+    cleanable filter.
+  - `executeCleanWorktrees`, lines 66-163: per-target manager resolution,
+    removal/preview dispatch, output, and failure continuation.
+- `cmd/ww/helpers.go`
+  - `managerForRepo`, lines 40-74: per-call repo selection and config reload.
+  - `loadRepoConfigForSelection`, lines 76-108: non-sandbox pre-load and final
+    effective config resolution.
+- `worktree/worktree.go`
+  - `Manager.Remove`, lines 688-762: per-target `WorktreeList` lookup followed by
+    the dry-run rendering or real mutation path.
+- `docs/specs/cli-commands.md`, lines 503 onward: clean selection, output,
+  continuation, dry-run, and removal safety contract.
+- `internal/testutil/performance_fixture.go`, lines 12-165: current one-merged-
+  worktree-per-repository fixture shape.
+- `cmd/ww/performance_test.go`, lines 58-77: clean dry-run benchmark assertion.
+- `tools/performance-budget.json`, lines 1-28: default 6 x 5 profile and 420 ms
+  clean budget introduced by PR #280.
+- `docs/specs/testing.md`, lines 12-27: fixture/budget and scale-override contract.
+
+## Code Change Map
+
+- `docs/specs/testing.md` (MODIFY)
+  - Retain the default budgeted profile and add a documented optional
+    cleanable-worktrees-per-repo override for targeted clean-heavy comparison.
+- `internal/testutil/performance_fixture.go` (MODIFY)
+  - Add a validated opt-in cleanable-density setting; default it to the existing
+    one merged worktree per repository.
+  - Create deterministic additional merged targets while retaining at least one
+    active tracked branch and exact expected output counts.
+- `tools/performance-budget.json` (MODIFY)
+  - Record the default cleanable density explicitly without changing benchmark
+    names, repetitions, or the existing default command shape and limits.
+- `tools/check-performance-budget.go` (MODIFY)
+  - Parse/validate/report the additional versioned fixture-profile field.
+- `tools/check-performance-budget_test.go` (MODIFY)
+  - Cover valid/invalid cleanable density and report formatting.
+- `worktree/worktree.go` (MODIFY)
+  - Extract shared validated preview construction from `Remove` after entry
+    lookup.
+  - Add a narrow preview method that accepts a `WorktreeInfo` originating from
+    the current list snapshot, rejects main/branchless/invalid inputs, and emits
+    the exact same `RemoveResult` and dry-run log without invoking Git.
+  - Keep non-dry-run `Remove` lookup and mutation behavior unchanged.
+- `worktree/worktree_test.go` (MODIFY)
+  - Prove snapshot preview and normal `Remove(...DryRun:true)` are equivalent for
+    hooks, path, branch, worktree index, keep-branch behavior, and errors.
+- `cmd/ww/sub_clean.go` (MODIFY)
+  - Cache `managerForRepo` results once per repository while iterating the
+    original target order.
+  - Use snapshot preview only when `glOpts.dryRun`; route real removals through
+    existing `Manager.Remove` so each mutation revalidates current Git state.
+  - Preserve per-target failure accumulation and text/JSON ordering.
+- `cmd/ww/sub_clean_test.go` (NEW)
+  - Cover repo-manager caching, dry-run snapshot dispatch, real-remove dispatch,
+    ordered output, and continued failures with focused seams.
+- `integration_test.go` (MODIFY)
+  - Compare `ww list --cleanable` with text/JSON `ww clean --dry-run` in a repo
+    containing multiple cleanable targets and lifecycle hook configuration.
+
+## Spec Changes
+
+- `docs/specs/testing.md`: add the optional cleanable-density investigation
+  profile while keeping PR #280's default budgeted profile intact.
+- `docs/specs/cli-commands.md`: no semantic change. Dry-run output and actual
+  cleanup safety/revalidation remain as currently specified.
+
+## Sub-tasks
+
+1. Make repeated clean preview work measurable
+   - Add the optional cleanable-density fixture setting as a measurement-only
+     first commit and capture a clean-heavy baseline before optimization.
+   - Also run the unchanged default `make perf-check` and retain list/clean
+     samples so fixture/tool changes cannot hide a regression.
+2. Reuse repository and snapshot state safely
+   - Extract and test shared preview rendering.
+   - Cache selected repo managers for the command invocation.
+   - Use snapshot preview only for dry-run; preserve fresh lookup before every
+     real mutation.
+3. Verify parity and performance
+   - Prove normal `remove --dry-run`, clean snapshot preview, text, and JSON
+     outputs agree.
+   - Re-run default and clean-heavy measurements on the same host.
+   - Require clean-heavy improvement outside baseline variation, unchanged list
+     behavior, and no meaningful default-profile regression before landing.
+
+## Dependencies and Parallelism
+
+- Follows plan 0041 so the shared list snapshot reflects all preceding
+  discovery/status/enumeration improvements.
+- The fixture-density extension and preview parity tests may proceed in
+  parallel. Command adoption depends on the shared preview helper.
+- Do not optimize actual mutation by trusting the initial snapshot in this plan;
+  weakening per-target revalidation would be a separate safety decision.
+
+## Verification
+
+- `go test ./cmd/ww ./worktree ./tools/...`
+- `go test ./...`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run the documented clean-heavy profile before and after with identical
+  repository/worktree/cleanable counts.
+- Confirm the implementation PR's GitHub-hosted performance job keeps default
+  list and clean within 400 ms / 420 ms. Judge local improvement from same-host
+  before/after samples; PR #280's 258.1 ms list and 269.6 ms clean medians are
+  historical GitHub-runner context only.

--- a/docs/exec-plan/todo/0043-list-clean-performance-06-persistent-discovery-cache.md
+++ b/docs/exec-plan/todo/0043-list-clean-performance-06-persistent-discovery-cache.md
@@ -1,0 +1,197 @@
+# List/Clean Performance 06: Persistent Discovery Cache
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Reuse validated start-path, current-worktree, main-worktree, workspace-root, and
+workspace-repository discovery results across separate `ww` invocations. Keep
+the cache strictly optional: a missing, unreadable, unwritable, corrupt, stale,
+or unknown-version cache must fall back to the normal discovery path without
+changing command output, errors, sandbox boundaries, or repository membership.
+
+Completion means a repeated `ww list` or `ww clean` from the same worktree can
+avoid the Git subprocesses used to rediscover its main worktree and validate
+unchanged workspace children, while a cold/mismatched entry produces exactly
+the uncached result. PR #280's budgeted command benchmarks remain cold-cache
+regression gates, and new warm-cache measurements demonstrate whether
+cross-command persistence materially improves the reported slow environment.
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Design Decision
+
+Use `filepath.Join(os.UserCacheDir(), "ww")` as the cache root:
+
+- Unix: `$XDG_CACHE_HOME/ww` when set, otherwise `$HOME/.cache/ww`.
+- macOS: `$HOME/Library/Caches/ww`.
+- Other supported behavior follows Go's `os.UserCacheDir` contract.
+
+Do not store cache data under `$XDG_CONFIG_HOME`, because config may be made
+read-only for sandbox safety and cache data is non-essential rather than user
+configuration. Do not fall back to `os.TempDir()` in normal execution. A temp
+directory is neither guaranteed to exist nor be accessible, may be periodically
+or reboot-cleaned, and a reusable shared-temp path adds ownership/symlink
+validation that the user-cache location avoids. If `os.UserCacheDir` cannot be
+resolved or used, run without caching. Tests should point the user-cache
+environment/home at a test-owned temp directory.
+
+The persistent cache stores topology hints only. It must not store final
+`WorktreeInfo`, branch/head values, merged/stale/active status, patch-equivalence
+results, or cleanable decisions. Normal commits, checkout, fetch, remote
+changes, and raw Git commands can change those values outside `ww` even when
+worktree creation/removal is normally performed through `ww`.
+
+This location, fail-open policy, trust boundary, and absence of a temp fallback
+are architectural choices. Record them in a new ADR during execution.
+
+## Static Analysis Findings
+
+- `newManagerWithOptions` and `loadManagerContext` repeatedly enter
+  `MainWorktreeDir` / `DetectWithOptions` for every short-lived CLI process.
+- `MainWorktreeDir` shells out to `git rev-parse --git-common-dir`; discovery
+  then scans bounded candidates and validates child repositories with
+  top-level, git-dir, and common-dir queries.
+- Plan 0038 removes duplicate work inside one invocation, but explicitly does
+  not reuse results across commands.
+- A cached current-worktree root can match later descendant start directories
+  by canonical containment and map them to the main root. Cached workspace
+  candidates can be validated with cheap sorted directory/`.git` marker
+  fingerprints before trusting their normalized repository set.
+- Caching `git worktree list --porcelain` output would also cache displayed
+  branch/head state. That can become stale after ordinary Git operations and is
+  excluded from this plan.
+
+## Existing Implementation References
+
+- `cmd/ww/main.go`
+  - `newManagerWithOptions`, lines 142-195: current pre-config resolution and
+    optional sandbox rerun.
+  - `loadManagerContext`, lines 197-224: workspace detection, main-root
+    resolution, and config loading.
+- `workspace/workspace.go`
+  - `DetectOptions` / `DetectWithOptions`, lines 39-129: discovery API and
+    sandbox-sensitive result construction.
+  - `detectContainingWorkspace` through `scanImmediateRepos`, lines 131-236:
+    bounded candidates and immediate-child enumeration.
+  - `isStandaloneRepoRoot`, lines 288-333: authoritative Git validation.
+  - `normalizeRepos`, lines 371-400: deterministic cached repository ordering.
+- `git/git.go`
+  - `MainWorktreeDir` / `TopLevelDir` / `GitCommonDir`, lines 528-552: current
+    Git-backed path identity queries.
+  - `WorktreeList`, lines 114-121: dynamic worktree/branch/head source that
+    remains uncached.
+- `docs/specs/workspace-discovery.md`, lines 30-90: black-box bounded and
+  sandbox discovery behavior.
+- `docs/design-decisions/adr/0014-global-config-path-and-overrides.md`, lines
+  12-29: existing separation of explicit user config and sandbox behavior.
+- `cmd/ww/performance_test.go`, lines 1-77, and
+  `tools/performance-budget.json`, lines 1-28: PR #280's benchmark names,
+  fixture, and advisory limits.
+
+## Code Change Map
+
+- `docs/design-decisions/README.md` (MODIFY)
+  - Index the persistent-cache location/trust decision.
+- `docs/design-decisions/adr/0017-persistent-cache-location-and-trust.md` (NEW)
+  - Record `os.UserCacheDir()/ww`, no normal tmp fallback, fail-open behavior,
+    topology-only data, validation before use, and sandbox non-expansion.
+- `docs/specs/README.md` (MODIFY)
+  - Link the cache contract.
+- `docs/specs/cache.md` (NEW)
+  - Define location, permissions, schema versioning, atomic writes, cache-hit
+    validation, silent miss/failure behavior, sandbox boundaries, and data that
+    must never be cached.
+- `docs/specs/testing.md` (MODIFY)
+  - Require test-owned user-cache isolation.
+  - Keep existing budgeted benchmarks cold-cache and add non-budgeted warm-cache
+    variants using the same PR #280 fixture and command boundary.
+- `internal/cache/store.go` (NEW)
+  - Resolve `os.UserCacheDir()/ww`, use application directory/file permissions
+    no broader than `0700`/`0600`, hash path-derived filenames, validate schema,
+    and replace files atomically with last-writer-wins behavior.
+  - Treat all read/write/parse failures as misses; cache failures must not write
+    warnings into normal stdout/stderr.
+- `internal/cache/topology.go` (NEW)
+  - Model canonical start/worktree/main/workspace paths, sandbox mode,
+    deterministic repo lists, and validation fingerprints.
+  - Reject entries whose paths disappear, change identity, escape the current
+    sandbox/bounded candidate set, or no longer match sorted immediate-child and
+    `.git` marker fingerprints.
+- `internal/cache/cache_test.go` (NEW)
+  - Cover path resolution, permissions, atomic replacement, concurrent writers,
+    corrupt/unknown schemas, tampered paths, symlink/path escape attempts,
+    fingerprint changes, and fail-open operation.
+- `workspace/workspace.go` (MODIFY)
+  - Add an optional discovery-cache seam to `DetectOptions` without changing
+    uncached callers.
+  - On a validated hit, return the same normalized `Workspace`; on any miss,
+    execute current discovery and publish a new hint.
+- `workspace/workspace_test.go` (MODIFY)
+  - Prove hit/miss parity for single repo, linked worktree, git/non-git workspace
+    roots, parent/grandparent selection, repo add/remove/move, and sandbox mode.
+- `cmd/ww/main.go` (MODIFY)
+  - Create the best-effort cache store once per invocation and pass it through
+    initial and sandbox-rerun discovery.
+  - Ensure a cached result cannot suppress config loading or change
+    config-selected sandbox behavior.
+- `internal/testutil/host.go` (MODIFY)
+  - Isolate user cache under test-owned temp state and expose cache reset/prime
+    helpers without writing to the developer's real cache.
+- `cmd/ww/performance_test.go` (MODIFY)
+  - Reset cache outside the timer for existing cold budgeted benchmarks.
+  - Add stable warm variants that prime once outside the timer and assert the
+    same entries/cleanable counts.
+- `integration_test.go` (MODIFY)
+  - Exercise separate CLI processes for cold/warm hits, invalidation/fallback,
+    concurrent cache writers, read-only cache roots, and sandbox restrictions.
+
+## Spec Changes
+
+- Add `docs/specs/cache.md` with the observable cache contract above.
+- Extend `docs/specs/testing.md` so tests never touch the operator's cache and
+  PR #280's existing benchmark/budget remains a cold-cache comparison while a
+  warm profile measures the new capability.
+- No `ww list`, `ww clean`, workspace membership, or status output changes.
+
+## Sub-tasks
+
+1. Specify and isolate cache storage
+   - Add ADR/spec first, implement `os.UserCacheDir()/ww`, atomic files, schema,
+     permissions, and fail-open behavior.
+   - Redirect unit/integration/performance cache state to test-owned temp roots.
+2. Add validated topology reuse
+   - Define canonical identity and immediate-child fingerprints.
+   - Integrate optional cache lookup/publication without broadening sandbox
+     discovery or caching dynamic Git/status data.
+3. Prove safety and performance
+   - Cover tamper, stale, move, deletion, concurrent process, read-only, and
+     unknown-schema cases.
+   - Run cold and warm PR #280 profiles on the same host and retain all samples.
+   - Require warm improvement outside run-to-run variation and no meaningful
+     cold regression before landing.
+
+## Dependencies and Parallelism
+
+- Depends on plan 0038 so persistent reuse builds on one canonical invocation-
+  local discovery path rather than preserving duplicate work.
+- May be implemented after 0039-0042; it must not be hidden behind plan 0041's
+  repository concurrency when measuring the discovery-specific warm path.
+- Plan 0044 depends on the cache storage/schema/test-isolation foundation here.
+- Store/ADR/spec work and workspace hit/miss tests may proceed in parallel after
+  the schema and trust boundary are fixed.
+
+## Verification
+
+- `go test ./internal/cache ./workspace ./cmd/ww`
+- `go test -race ./internal/cache ./workspace ./cmd/ww`
+- `go test ./...`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run documented cold and warm variants with identical PR #280 repo/worktree
+  counts and record samples, cache-hit proof, and cache filesystem location.
+- Confirm the implementation PR's GitHub-hosted cold performance job remains
+  within 400 ms list / 420 ms clean. Judge warm improvement using same-host
+  before/after measurements, not those runner-specific limits.

--- a/docs/exec-plan/todo/0044-list-clean-performance-07-positive-remote-cache.md
+++ b/docs/exec-plan/todo/0044-list-clean-performance-07-positive-remote-cache.md
@@ -1,0 +1,183 @@
+# List/Clean Performance 07: Conservative Positive Remote Cache
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Avoid repeated live `git ls-remote --heads` calls when recent evidence already
+proves that every relevant tracked branch exists on the same remote. Cache only
+positive presence for a fixed short lifetime; never persist absence or a final
+`stale`/`cleanable` decision.
+
+Completion means repeated `ww list` / `ww clean --dry-run` calls within 30
+seconds can skip unchanged positive remote probes, while a missing branch,
+expired entry, changed remote identity, corrupt cache, or network failure follows
+the current live-query/error path. A stale positive may conservatively delay
+`stale` classification for at most the TTL, but it can never make an active
+branch cleanable.
+
+Addresses: N/A - performance follow-up to the completed measurement issue
+`docs/issues/done/0037-list-clean-performance-budget.md`.
+
+## Design Decision
+
+- Cache only branch names observed as present from a successful complete
+  `ls-remote --heads <remote>` response.
+- Use a fixed 30-second TTL; do not add configuration or a new CLI flag.
+- A hit is usable only when every currently requested candidate branch is in
+  the unexpired positive set. If any candidate is absent from the cached set,
+  run the live full-remote query and replace the positive set.
+- Never cache absence. Never serve an expired entry after a live-query failure.
+  Preserve the current error rather than silently using stale data.
+- Key entries by repository common-dir identity, remote name, and a hash of the
+  effective configured remote URL values. Never persist raw remote URLs because
+  they may contain credentials.
+- Reuse the `os.UserCacheDir()/ww` store from plan 0043; do not use config or
+  temp directories in normal execution.
+
+This asymmetric policy is safe for cleanup: a deleted remote branch that is
+still in a positive cache remains temporarily `active`, whereas caching a false
+absence could incorrectly produce `stale`. Record the positive-only/TTL/error
+decision in a new ADR during execution.
+
+## Static Analysis Findings
+
+- `listRepo` batches branch existence into one `ListRemoteBranches` call per
+  unique remote and repeats those live calls on every CLI invocation.
+- In a workspace with multiple real remotes, network/credential latency remains
+  additive before plan 0041 and consumes concurrent slots after it.
+- Plan 0039 removes per-branch local config subprocesses but intentionally keeps
+  live remote enumeration unchanged.
+- PR #280 uses local bare remotes, so it detects cache overhead/regression but
+  understates network benefit. A controlled delayed-remote test and warm-cache
+  benchmark are required alongside the existing budget.
+
+## Existing Implementation References
+
+- `worktree/worktree.go`, lines 456-540: status aggregation, unique-remote map,
+  and `ListRemoteBranches` call site shared by list/clean.
+- `git/git.go`
+  - `BranchRemote`, lines 258-266: repository tracking identity input.
+  - `HasRemote` / `RemoteBranchExists` / `ListRemoteBranches`, lines 278-326:
+    existing remote URL/existence and complete branch-set queries.
+  - `GitCommonDir`, lines 546-552: repository identity input.
+- `docs/design-decisions/adr/0005-worktree-status-precedence.md`, lines 1-23:
+  conservative merged/stale/active cleanup policy.
+- `docs/specs/cli-commands.md`, lines 377-441 and 503 onward: stale and
+  cleanable behavior that must remain safe.
+- `docs/specs/git-operations.md`, lines 138-153: current live remote presence
+  contract.
+- `docs/specs/cache.md` (created by plan 0043): persistent-store location,
+  trust, and fail-open rules.
+- `cmd/ww/performance_test.go`, lines 1-77, and
+  `internal/testutil/performance_fixture.go`, lines 53-165: PR #280's local
+  remote fixture and command boundary.
+
+## Code Change Map
+
+- `docs/design-decisions/README.md` (MODIFY)
+  - Index the conservative positive-remote cache decision.
+- `docs/design-decisions/adr/0018-positive-remote-cache.md` (NEW)
+  - Record positive-only evidence, 30-second TTL, full live refresh on any
+    missing candidate, no expired fallback, and credential-safe identity keys.
+- `docs/specs/cache.md` (MODIFY)
+  - Define remote cache key/value/TTL, positive-only safety, and invalidation.
+- `docs/specs/git-operations.md` (MODIFY)
+  - State when a recent positive set may replace a live `ls-remote`, and that
+    absence/expiry still requires the existing live query.
+- `docs/specs/testing.md` (MODIFY)
+  - Add warm positive-cache coverage and a deterministic delayed-remote test;
+    keep existing budgeted benchmarks cold.
+- `internal/cache/remote.go` (NEW)
+  - Store observed-at timestamps and positive branch sets using plan 0043's
+    versioned/atomic store.
+  - Hash common-dir identity and configured remote URL values; store no URL,
+    credential, token, command output, absence, or status decision.
+  - Accept a clock seam for deterministic TTL tests.
+- `internal/cache/remote_test.go` (NEW)
+  - Cover full hit, one requested branch absent, exact TTL boundary, expiry,
+    remote URL/name/common-dir changes, clock behavior, corrupt/tampered data,
+    credential non-persistence, and concurrent writers.
+- `git/git.go` (MODIFY)
+  - Add a narrowly scoped helper to read all effective URL values needed for a
+    credential-safe identity hash without exposing them in errors/cache files.
+  - Keep the uncached `ListRemoteBranches` behavior available.
+- `git/git_test.go` (MODIFY)
+  - Cover multiple remote URLs, URL changes, unusual branch names, and live
+    query failure behavior.
+- `worktree/worktree.go` (MODIFY)
+  - Inject an optional positive-remote cache into repository status evaluation.
+  - Skip live enumeration only when every candidate branch has fresh positive
+    evidence; otherwise query live, classify from that response, and replace
+    the positive set.
+  - Preserve output order, merged precedence, base-unknown degradation, and
+    errors.
+- `worktree/worktree_test.go` (MODIFY)
+  - Prove cached positives stay active, deleted branches are at worst delayed,
+    cache misses/expiry detect stale live, and no cache state can create a false
+    merged/stale/cleanable result.
+- `cmd/ww/main.go` (MODIFY)
+  - Pass plan 0043's best-effort cache store into list/status managers without
+    changing commands that do not need remote status.
+- `internal/testutil/performance_fixture.go` (MODIFY)
+  - Add an opt-in deterministic remote-delay wrapper/profile for investigation;
+    retain local bare remotes and default counts for budgeted PR #280 runs.
+- `cmd/ww/performance_test.go` (MODIFY)
+  - Keep cold budgeted benchmarks comparable and add/extend warm variants that
+    prime positive remote evidence outside the timer.
+- `integration_test.go` (MODIFY)
+  - Execute separate CLI processes proving hit/miss/expiry, branch deletion
+    delay followed by live stale detection, URL changes, remote errors, and
+    read-only/unavailable cache fallback.
+
+## Spec Changes
+
+- `docs/specs/cache.md`: add the 30-second positive-only remote cache contract.
+- `docs/specs/git-operations.md`: allow a fresh complete positive set to avoid
+  `ls-remote`; continue requiring live evidence for absence and after expiry.
+- `docs/specs/testing.md`: separate cold budget protection from warm/delayed-
+  remote benefit measurement.
+- `docs/specs/cli-commands.md`: clarify, if necessary, that remote deletion may
+  remain `active` for at most the positive-cache TTL. It must never become
+  prematurely cleanable.
+
+## Sub-tasks
+
+1. Specify conservative semantics
+   - Add ADR/spec changes first, including TTL boundary, credentials, error
+     behavior, and the bounded active-delay statement.
+2. Add positive cache and status integration
+   - Implement identity hashing, clocked entries, all-candidates hit logic, and
+     live refresh without caching absence.
+   - Preserve uncached behavior when the store is missing or unusable.
+3. Prove safety and benefit
+   - Test deletion, URL changes, expiry, network errors, tampering, and
+     concurrent processes.
+   - Compare cold, warm, and controlled-delayed-remote measurements with the
+     same PR #280 fixture scale.
+   - Require a warm/delayed improvement outside variation and no meaningful
+     cold regression before landing.
+
+## Dependencies and Parallelism
+
+- Depends on plan 0039 for batched candidate/tracking metadata and plan 0043
+  for persistent storage, schema, atomicity, permissions, and test isolation.
+- Should be evaluated after plan 0041 because repository concurrency changes
+  the wall-clock impact of remote latency.
+- ADR/spec work and cache unit tests may proceed in parallel. Status integration
+  waits for the cache key/value interface.
+
+## Verification
+
+- `go test ./internal/cache ./git ./worktree ./cmd/ww`
+- `go test -race ./internal/cache ./worktree ./cmd/ww`
+- Targeted integration tests for fresh hit, one-branch miss, exact expiry,
+  deletion delay, URL change, remote failure, and unavailable cache.
+- `go test ./...`
+- `make test`
+- `make test-all`
+- `make lint`
+- `make perf-check`
+- Run cold, warm, and delayed-remote profiles with identical PR #280
+  repo/worktree counts and record `ls-remote` call counts plus timings.
+- Confirm the GitHub-hosted cold job remains within 400 ms / 420 ms. Judge the
+  cache on same-host warm/delayed evidence rather than those cold budgets.


### PR DESCRIPTION
## Plan / Issues

- **Plan**:
  - `docs/exec-plan/todo/0038-list-clean-performance-01-discovery-reuse.md`
  - `docs/exec-plan/todo/0039-list-clean-performance-02-tracking-batch.md`
  - `docs/exec-plan/todo/0040-list-clean-performance-03-patch-cache.md`
  - `docs/exec-plan/todo/0041-list-clean-performance-04-bounded-repo-parallelism.md`
  - `docs/exec-plan/todo/0042-list-clean-performance-05-clean-snapshot-reuse.md`
  - `docs/exec-plan/todo/0043-list-clean-performance-06-persistent-discovery-cache.md`
  - `docs/exec-plan/todo/0044-list-clean-performance-07-positive-remote-cache.md`
- **Issues**: N/A
- **Closes**: N/A

## Type

- [ ] Project plan
- [x] Execution plan
- [ ] Feature / bug implementation
- [ ] Refactor / chore
- [ ] Documentation

## Summary

Splits `ww list` / `ww clean` performance work into seven behavior-preserving execution plans based on static analysis: discovery/startup reuse, branch tracking batching, patch-equivalence caching, bounded repository parallelism, clean dry-run snapshot reuse, a persistent validated discovery cache, and a conservative positive-only remote cache.

Every plan uses the command-boundary benchmarks and advisory budgets introduced by PR #280 as the common regression indicator. Persistent-cache plans preserve the existing cold benchmarks and add warm-cache evidence so cross-command benefit is measured without weakening regression protection.

## Intent

- Persistent cache data belongs under `os.UserCacheDir()/ww`: `$XDG_CACHE_HOME/ww` or `~/.cache/ww` on Unix, and the platform user-cache directory elsewhere.
- Normal execution does not fall back to a shared temp directory. Cache path/write failures silently use the uncached path; tests isolate the user-cache root under temp state.
- Persistent discovery cache stores validated topology hints only, never final worktree status or cleanable decisions.
- Remote caching stores only fresh positive presence for 30 seconds. Absence and expired entries always require a live query, preventing false cleanable results.

## Verification

- `./tools/workflow-lint.sh --mode=pre-push` - passed
- `git diff origin/main...HEAD --check` - passed
- Static code-path review with Semble across `cmd/ww`, `workspace`, `worktree`, `git`, config paths, and the PR #280 performance fixture/budget implementation
- Cache location checked against the XDG Base Directory specification and Go `os.UserCacheDir` contract

## Checklist

- [x] Fresh branch from current `main`
- [x] Specs updated before code, if code changed
- [x] Plan and linked local issues moved to `done/`, if resolved
- [x] Fixable workflow-linter findings resolved or justified
- [x] No unresolved blockers

## Reviewer notes

- Plans 0038 and 0039 may execute independently.
- Plan 0040 follows 0039; plan 0041 follows 0038-0040; plan 0042 follows 0041.
- Plan 0043 follows 0038 and provides the persistent store used by 0044. Plan 0044 also follows 0039 and should be evaluated after 0041.
- The split deliberately treats workspace detection as a strong hypothesis rather than a foregone conclusion. Static analysis also found O(worktree) branch metadata queries, repeated base-history patch-id work, serial live remote checks across repos, and clean dry-run re-enumeration.
- The existing 6 repo x 5 worktree benchmark remains the cold default comparison. Targeted scaled, warm, and delayed-remote profiles are added only where that default does not expose a specific path.
