### PR TITLE
docs: plan historical workflow artifact retention

### DIFF
--- a/docs/exec-plan/todo/0045-historical-workflow-artifact-retention.md
+++ b/docs/exec-plan/todo/0045-historical-workflow-artifact-retention.md
@@ -1,13 +1,14 @@
-# Historical workflow artifact retention
+# Completed plan and local Markdown issue history retention
 
 > **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
 
 ## Objective
 
-Remove completed plan and local-issue bodies from the checked-out repository to
-make normal code/task discovery active-only. Preserve auditability through the
-plan PR, implementation PR, and Git history rather than `done/` directories or
-long commit messages.
+Remove completed plan and local Markdown issue bodies from the checked-out
+repository to make normal code/task discovery active-only. Specifically remove
+`docs/exec-plan/done/` and `docs/issues/done/`, while preserving auditability
+through the plan PR, implementation PR, and Git history rather than long commit
+messages.
 
 ## Change map
 

--- a/docs/exec-plan/todo/0045-historical-workflow-artifact-retention.md
+++ b/docs/exec-plan/todo/0045-historical-workflow-artifact-retention.md
@@ -1,0 +1,26 @@
+# Historical workflow artifact retention
+
+> **Execution**: Use `/execute-task` to implement this plan. After implementation is complete, use `/review-task` to prepare and create the PR.
+
+## Objective
+
+Remove completed plan and local-issue bodies from the checked-out repository to
+make normal code/task discovery active-only. Preserve auditability through the
+plan PR, implementation PR, and Git history rather than `done/` directories or
+long commit messages.
+
+## Change map
+
+- (MODIFY) `AGENTS.md`, `docs/exec-plan/todo/README.md`, `docs/issues/README.md`, `.github/copilot-instructions.md`, and all current workflow guidance that refers to `done/`.
+- (MODIFY) `tools/workflow-lint.sh` and its focused test harness. Retain matching active-plan enforcement. Replace `todo`→`done` rename detection with a closeout-diff rule that reads the deleted plan from the merge-base side, requires deletion of explicit linked local issues, and retains external GitHub closing-keyword checks.
+- (DELETE) all files under `docs/exec-plan/done/` and `docs/issues/done/`, then remove empty directories.
+
+## Execution order
+
+1. Specify the deletion-based lifecycle in the workflow-linter contract before code.
+2. Implement and test separate active-plan and deleted-plan closeout paths.
+3. Update guidance/templates, remove historical artifacts, and sweep stale references without rewriting ADRs or Git history.
+
+## Verification
+
+Run focused linter cases for active plan, valid deletion, omitted linked issue, and external issue metadata; then run `make test`, `make lint`, `git diff --check`, workflow-linter checks, and prove retrieval with `git log --all -- docs/exec-plan`.


### PR DESCRIPTION
## Summary\n- Add the child-repository plan for active-only workflow artifacts.\n\n## Plan\n- docs/exec-plan/todo/0045-historical-workflow-artifact-retention.md\n\n## Verification\n- git diff --check\n- ./tools/workflow-lint.sh --mode=pre-push